### PR TITLE
인증 도메인 커스텀 예외 처리 추가

### DIFF
--- a/src/main/java/com/example/daobe/auth/application/AuthService.java
+++ b/src/main/java/com/example/daobe/auth/application/AuthService.java
@@ -1,8 +1,12 @@
 package com.example.daobe.auth.application;
 
+import static com.example.daobe.auth.exception.AuthExceptionType.INVALID_TOKEN;
+import static com.example.daobe.auth.exception.AuthExceptionType.UN_MATCH_USER_INFO;
+
 import com.example.daobe.auth.application.dto.TokenResponseDto;
 import com.example.daobe.auth.domain.Token;
 import com.example.daobe.auth.domain.repository.TokenRepository;
+import com.example.daobe.auth.exception.AuthException;
 import com.example.daobe.user.entity.User;
 import com.example.daobe.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -38,7 +42,7 @@ public class AuthService {
     public TokenResponseDto reissueTokenPair(String currentToken) {
         String tokenId = tokenExtractor.extractRefreshToken(currentToken);
         Token findToken = tokenRepository.findByTokenId(tokenId)
-                .orElseThrow(() -> new RuntimeException("유효하지 않은 토큰"));
+                .orElseThrow(() -> new AuthException(INVALID_TOKEN));
 
         tokenRepository.deleteByTokenId(findToken.getTokenId());
         Token newToken = Token.builder()
@@ -55,10 +59,10 @@ public class AuthService {
     public void logout(Long userId, String currentToken) {
         String tokenId = tokenExtractor.extractRefreshToken(currentToken);
         Token findToken = tokenRepository.findByTokenId(tokenId)
-                .orElseThrow(() -> new RuntimeException("유효하지 않은 토큰"));
+                .orElseThrow(() -> new AuthException(INVALID_TOKEN));
 
         if (!findToken.isMatchMemberId(userId)) {
-            throw new RuntimeException("일치하지 않는 유저입니다");
+            throw new AuthException(UN_MATCH_USER_INFO);
         }
 
         tokenRepository.deleteByTokenId(findToken.getTokenId());

--- a/src/main/java/com/example/daobe/auth/exception/AuthException.java
+++ b/src/main/java/com/example/daobe/auth/exception/AuthException.java
@@ -1,0 +1,10 @@
+package com.example.daobe.auth.exception;
+
+import com.example.daobe.common.exception.BaseException;
+
+public class AuthException extends BaseException {
+
+    public AuthException(AuthExceptionType exceptionType) {
+        super(exceptionType);
+    }
+}

--- a/src/main/java/com/example/daobe/auth/exception/AuthExceptionType.java
+++ b/src/main/java/com/example/daobe/auth/exception/AuthExceptionType.java
@@ -20,11 +20,11 @@ public enum AuthExceptionType implements BaseExceptionType {
 
     @Override
     public String message() {
-        return "";
+        return message;
     }
 
     @Override
     public HttpStatus status() {
-        return null;
+        return status;
     }
 }

--- a/src/main/java/com/example/daobe/auth/exception/AuthExceptionType.java
+++ b/src/main/java/com/example/daobe/auth/exception/AuthExceptionType.java
@@ -1,0 +1,30 @@
+package com.example.daobe.auth.exception;
+
+import com.example.daobe.common.exception.BaseExceptionType;
+import org.springframework.http.HttpStatus;
+
+public enum AuthExceptionType implements BaseExceptionType {
+    INVALID_TOKEN("유효하지 않은 토큰 입니다", HttpStatus.UNAUTHORIZED),
+    INVALID_TOKEN_TYPE("유효하지 않은 토큰 타입 입니다.", HttpStatus.BAD_REQUEST),
+    ALREADY_EXPIRED_TOKEN("이미 만료된 토큰 입니다.", HttpStatus.UNAUTHORIZED),
+    UN_MATCH_USER_INFO("토큰에 저장된 사용자와 일치하지 않는 사용자입니다.", HttpStatus.UNAUTHORIZED),
+    ;
+
+    private final String message;
+    private final HttpStatus status;
+
+    AuthExceptionType(String message, HttpStatus status) {
+        this.message = message;
+        this.status = status;
+    }
+
+    @Override
+    public String message() {
+        return "";
+    }
+
+    @Override
+    public HttpStatus status() {
+        return null;
+    }
+}

--- a/src/main/java/com/example/daobe/auth/infrastructure/jwt/JwtExtractor.java
+++ b/src/main/java/com/example/daobe/auth/infrastructure/jwt/JwtExtractor.java
@@ -1,6 +1,11 @@
 package com.example.daobe.auth.infrastructure.jwt;
 
+import static com.example.daobe.auth.exception.AuthExceptionType.ALREADY_EXPIRED_TOKEN;
+import static com.example.daobe.auth.exception.AuthExceptionType.INVALID_TOKEN;
+import static com.example.daobe.auth.exception.AuthExceptionType.INVALID_TOKEN_TYPE;
+
 import com.example.daobe.auth.application.TokenExtractor;
+import com.example.daobe.auth.exception.AuthException;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.JwtParser;
@@ -44,7 +49,7 @@ public class JwtExtractor implements TokenExtractor {
         if (subject.equals(expectedTokenType)) {
             return claims.get(claimKey, T);
         }
-        throw new RuntimeException("INVALID_TOKEN_TYPE");
+        throw new AuthException(INVALID_TOKEN_TYPE);
     }
 
     private Claims parseClaim(String token) {
@@ -52,9 +57,9 @@ public class JwtExtractor implements TokenExtractor {
             return jwtParser.parseClaimsJws(token)
                     .getBody();
         } catch (ExpiredJwtException ex) {
-            throw new RuntimeException("EXPIRED_TOKEN");
+            throw new AuthException(ALREADY_EXPIRED_TOKEN);
         } catch (Exception ex) {
-            throw new RuntimeException("INVALID_TOKEN");
+            throw new AuthException(INVALID_TOKEN);
         }
     }
 }


### PR DESCRIPTION
## 📝 개요

- 인증 도메인 커스텀 예외 처리 추가

## ✨ 변경 사항

- 코드나 기능의 주요 변경 사항을 설명합니다.

    - ✨ 인증 도메인에서 사용될 커스텀 예외 클래스 및 타입 추가
    - ✨ 인증 도메인 내 `RuntimeException` 을 커스텀 예외 클래스로 리팩토링

## 🔗 관련 이슈

- 이 PR과 관련된 이슈 번호를 연결합니다. (없으면 생략))
    - 예: closes #50 
