### PR TITLE
파일 업로드 용량 및 확장자 검증

### DIFF
--- a/src/main/java/com/example/daobe/common/utils/DaoFileExtensionUtils.java
+++ b/src/main/java/com/example/daobe/common/utils/DaoFileExtensionUtils.java
@@ -1,0 +1,35 @@
+package com.example.daobe.common.utils;
+
+import static com.example.daobe.objet.exception.ObjetExceptionType.INVALID_OBJET_IMAGE_EXTENSIONS;
+
+import com.example.daobe.objet.exception.ObjetException;
+import java.util.Arrays;
+import java.util.List;
+import org.springframework.web.multipart.MultipartFile;
+
+public class DaoFileExtensionUtils {
+
+    private static final List<String> allowedExtensions = Arrays.asList("jpeg", "jpg", "png", "webp");
+
+    // 파일 확장자 추출
+    public static String getFileExtension(String fileName) {
+        int dotIndex = fileName.lastIndexOf('.');
+        if (dotIndex > 0 && dotIndex < fileName.length() - 1) {
+            return fileName.substring(dotIndex + 1);
+        }
+        return "";
+    }
+
+    // 파일 확장자 검증
+    public static void validateFileExtension(MultipartFile file) {
+        String fileName = file.getOriginalFilename();
+
+        if (fileName != null) {
+            String fileExtension = getFileExtension(fileName);
+
+            if (!allowedExtensions.contains(fileExtension.toLowerCase())) {
+                throw new ObjetException(INVALID_OBJET_IMAGE_EXTENSIONS);
+            }
+        }
+    }
+}

--- a/src/main/java/com/example/daobe/common/utils/DaoFileExtensionUtils.java
+++ b/src/main/java/com/example/daobe/common/utils/DaoFileExtensionUtils.java
@@ -1,8 +1,5 @@
 package com.example.daobe.common.utils;
 
-import static com.example.daobe.objet.exception.ObjetExceptionType.INVALID_OBJET_IMAGE_EXTENSIONS;
-
-import com.example.daobe.objet.exception.ObjetException;
 import java.util.Arrays;
 import java.util.List;
 import org.springframework.web.multipart.MultipartFile;
@@ -21,15 +18,13 @@ public class DaoFileExtensionUtils {
     }
 
     // 파일 확장자 검증
-    public static void validateFileExtension(MultipartFile file) {
+    public static boolean isValidFileExtension(MultipartFile file) {
         String fileName = file.getOriginalFilename();
 
         if (fileName != null) {
             String fileExtension = getFileExtension(fileName);
-
-            if (!allowedExtensions.contains(fileExtension.toLowerCase())) {
-                throw new ObjetException(INVALID_OBJET_IMAGE_EXTENSIONS);
-            }
+            return allowedExtensions.contains(fileExtension.toLowerCase());
         }
+        return false;
     }
 }

--- a/src/main/java/com/example/daobe/objet/exception/ObjetExceptionType.java
+++ b/src/main/java/com/example/daobe/objet/exception/ObjetExceptionType.java
@@ -6,6 +6,8 @@ import org.springframework.http.HttpStatus;
 public enum ObjetExceptionType implements BaseExceptionType {
     INVALID_OBJET_ID_EXCEPTION("유효하지 않은 오브제 ID입니다.", HttpStatus.NOT_FOUND),
     NO_PERMISSIONS_ON_OBJET("오브제에 대한 권한이 없습니다.", HttpStatus.UNAUTHORIZED),
+    INVALID_OBJET_IMAGE_EXTENSIONS("오브제 이미지의 확장자가 올바르지 않습니다.", HttpStatus.BAD_REQUEST),
+    INVALID_OBJET_IMAGE("오브제 이미지가 유효하지 않습니다.", HttpStatus.BAD_REQUEST),
     ;
 
     private final String message;

--- a/src/main/java/com/example/daobe/objet/presentation/ObjetController.java
+++ b/src/main/java/com/example/daobe/objet/presentation/ObjetController.java
@@ -1,5 +1,7 @@
 package com.example.daobe.objet.presentation;
 
+import static com.example.daobe.objet.exception.ObjetExceptionType.INVALID_OBJET_IMAGE_EXTENSIONS;
+
 import com.example.daobe.common.response.ApiResponse;
 import com.example.daobe.common.utils.DaoFileExtensionUtils;
 import com.example.daobe.objet.application.ObjetService;
@@ -8,6 +10,7 @@ import com.example.daobe.objet.application.dto.ObjetCreateResponseDto;
 import com.example.daobe.objet.application.dto.ObjetDetailInfoDto;
 import com.example.daobe.objet.application.dto.ObjetInfoDto;
 import com.example.daobe.objet.application.dto.ObjetUpdateRequestDto;
+import com.example.daobe.objet.exception.ObjetException;
 import com.example.daobe.upload.application.UploadService;
 import com.example.daobe.upload.application.dto.UploadImageResponse;
 import java.util.List;
@@ -49,7 +52,10 @@ public class ObjetController {
             @RequestParam("description") String description,
             @RequestParam("objet_image") MultipartFile file
     ) {
-        DaoFileExtensionUtils.validateFileExtension(file);
+
+        if (!DaoFileExtensionUtils.isValidFileExtension(file)) {
+            throw new ObjetException(INVALID_OBJET_IMAGE_EXTENSIONS);
+        }
 
         UploadImageResponse uploadImageResponse = uploadService.uploadImage(file);
 
@@ -92,7 +98,9 @@ public class ObjetController {
             @RequestParam(value = "objet_image", required = false) MultipartFile file
     ) {
 
-        DaoFileExtensionUtils.validateFileExtension(file);
+        if (!DaoFileExtensionUtils.isValidFileExtension(file)) {
+            throw new ObjetException(INVALID_OBJET_IMAGE_EXTENSIONS);
+        }
 
         ObjetUpdateRequestDto request = new ObjetUpdateRequestDto(objetId, owners, name, description);
 

--- a/src/main/java/com/example/daobe/objet/presentation/ObjetController.java
+++ b/src/main/java/com/example/daobe/objet/presentation/ObjetController.java
@@ -1,6 +1,7 @@
 package com.example.daobe.objet.presentation;
 
 import com.example.daobe.common.response.ApiResponse;
+import com.example.daobe.common.utils.DaoFileExtensionUtils;
 import com.example.daobe.objet.application.ObjetService;
 import com.example.daobe.objet.application.dto.ObjetCreateRequestDto;
 import com.example.daobe.objet.application.dto.ObjetCreateResponseDto;
@@ -48,10 +49,11 @@ public class ObjetController {
             @RequestParam("description") String description,
             @RequestParam("objet_image") MultipartFile file
     ) {
+        DaoFileExtensionUtils.validateFileExtension(file);
+
         UploadImageResponse uploadImageResponse = uploadService.uploadImage(file);
 
         ObjetCreateRequestDto request = new ObjetCreateRequestDto(owners, name, description, type, loungeId);
-
         ObjetCreateResponseDto ObjetCreateResponse = objetService.create(userId, request, uploadImageResponse.image());
 
         return ResponseEntity.status(HttpStatus.CREATED)
@@ -89,6 +91,9 @@ public class ObjetController {
             @RequestParam("description") String description,
             @RequestParam(value = "objet_image", required = false) MultipartFile file
     ) {
+
+        DaoFileExtensionUtils.validateFileExtension(file);
+
         ObjetUpdateRequestDto request = new ObjetUpdateRequestDto(objetId, owners, name, description);
 
         ObjetCreateResponseDto objetUpdateResponse;

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -2,6 +2,10 @@ spring:
   jackson:
     property-naming-strategy: SNAKE_CASE
 
+  servlet:
+    multipart:
+      max-file-size: 10MB
+
   cors:
     allowed-methods: ${ALLOWED_METHODS}
     allowed-origins: ${ALLOWED_ORIGINS}


### PR DESCRIPTION
## 📝 개요

- 파일 업로드 용량 및 확장자 검증

## ✨ 변경 사항

- 코드나 기능의 주요 변경 사항을 설명합니다.

    - ✨ 파일 업로드 10mb 제한 추가
    - ✨ 이미지 확장자 "jpeg", "jpg", "png", "webp" 로 제한
    - ✨ 오브제 생성 및 수정 로직에 확장자 검증 추가
