### PR TITLE
도메인 패키지 명 수정 및 기본 엔티티 클래스가 추가되지 않은 엔티티  수정

### DIFF
--- a/src/main/java/com/example/daobe/common/domain/BaseTimeEntity.java
+++ b/src/main/java/com/example/daobe/common/domain/BaseTimeEntity.java
@@ -1,4 +1,4 @@
-package com.example.daobe.common.entity;
+package com.example.daobe.common.domain;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;

--- a/src/main/java/com/example/daobe/lounge/domain/Lounge.java
+++ b/src/main/java/com/example/daobe/lounge/domain/Lounge.java
@@ -1,5 +1,6 @@
 package com.example.daobe.lounge.domain;
 
+import com.example.daobe.common.domain.BaseTimeEntity;
 import com.example.daobe.lounge.exception.LoungeException;
 import com.example.daobe.lounge.exception.LoungeExceptionType;
 import com.example.daobe.objet.domain.Objet;
@@ -27,7 +28,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Table(name = "lounges")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Lounge {
+public class Lounge extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/example/daobe/myroom/domain/MyRoom.java
+++ b/src/main/java/com/example/daobe/myroom/domain/MyRoom.java
@@ -2,7 +2,7 @@ package com.example.daobe.myroom.domain;
 
 import static com.example.daobe.myroom.exception.MyRoomExceptionType.FORBIDDEN_MY_ROOM_MODIFICATION;
 
-import com.example.daobe.common.entity.BaseTimeEntity;
+import com.example.daobe.common.domain.BaseTimeEntity;
 import com.example.daobe.myroom.exception.MyRoomException;
 import com.example.daobe.user.domain.User;
 import jakarta.persistence.Column;

--- a/src/main/java/com/example/daobe/notification/domain/Notification.java
+++ b/src/main/java/com/example/daobe/notification/domain/Notification.java
@@ -1,6 +1,6 @@
 package com.example.daobe.notification.domain;
 
-import com.example.daobe.common.entity.BaseTimeEntity;
+import com.example.daobe.common.domain.BaseTimeEntity;
 import com.example.daobe.user.domain.User;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;

--- a/src/main/java/com/example/daobe/objet/domain/Objet.java
+++ b/src/main/java/com/example/daobe/objet/domain/Objet.java
@@ -1,6 +1,6 @@
 package com.example.daobe.objet.domain;
 
-import com.example.daobe.common.entity.BaseTimeEntity;
+import com.example.daobe.common.domain.BaseTimeEntity;
 import com.example.daobe.lounge.domain.Lounge;
 import com.example.daobe.objet.application.dto.ObjetCreateResponseDto;
 import com.example.daobe.user.domain.User;

--- a/src/main/java/com/example/daobe/user/domain/User.java
+++ b/src/main/java/com/example/daobe/user/domain/User.java
@@ -1,6 +1,6 @@
 package com.example.daobe.user.domain;
 
-import com.example.daobe.common.entity.BaseTimeEntity;
+import com.example.daobe.common.domain.BaseTimeEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;


### PR DESCRIPTION
## 📝 개요

- 도메인 패키지 명 수정 및 기본 엔티티 클래스가 추가되지 않은 엔티티  수정

## ✨ 변경 사항

- 코드나 기능의 주요 변경 사항을 설명합니다.

    - ✨ `common` 패키지의 `entity` 패키지를 `doamin` 으로 수정
    - ✨ 라운지 엔티티에 `BaseTimeEntity` 추가
