### PR TITLE
배포 실패시 디스코드 알림 기능 추가

### DIFF
--- a/.github/workflows/deploy-failure-notice.yml
+++ b/.github/workflows/deploy-failure-notice.yml
@@ -1,0 +1,19 @@
+name: 배포 실패 알림
+
+on:
+  workflow_run:
+    workflows: [ "백엔드 DEV CD" ]
+    types:
+      - completed
+
+jobs:
+  notify-failure:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'failure' }}
+
+    steps:
+      - name: 배포 실패 디스코드 알림
+        run: |
+          curl -H "Content-Type: application/json" \
+               -d "{\"content\": \"${{ secrets.DISCORD_NOTICE_MESSAGE }}\"}" \
+               ${{ secrets.DISCORD_WEBHOOK_URL }}


### PR DESCRIPTION
## 📝 개요

- 배포 실패시 디스코드 알림 기능 추가

## ✨ 변경 사항

- 코드나 기능의 주요 변경 사항을 설명합니다.

    - ✨ 배포 Github Actions 실패시 디스코드 알림 기능 추가

## 🔗 관련 이슈

- 이 PR과 관련된 이슈 번호를 연결합니다. (없으면 생략))
    - closes #107 
