### PR TITLE
SSE 알림 페이로드 수정 및 알림 저장 및 조회 로직 추가

### DIFF
--- a/src/main/java/com/example/daobe/common/domain/DomainEvent.java
+++ b/src/main/java/com/example/daobe/common/domain/DomainEvent.java
@@ -2,6 +2,8 @@ package com.example.daobe.common.domain;
 
 public interface DomainEvent {
 
+    Long getDomainId();
+
     Long getSendUserId();
 
     Long getReceiveUserId();

--- a/src/main/java/com/example/daobe/lounge/domain/event/LoungeInviteEvent.java
+++ b/src/main/java/com/example/daobe/lounge/domain/event/LoungeInviteEvent.java
@@ -7,11 +7,13 @@ public class LoungeInviteEvent implements DomainEvent {
 
     private static final String LOUNGE_NOT_CREATED_EXCEPTION_MESSAGE = "아직 생성되지 않은 라운지";
 
+    private final Long domainId;
     private final Long sendUserId;
     private final Long receiveUserId;
 
     public LoungeInviteEvent(Long sendUserId, LoungeSharer loungeSharer) {
         validate(loungeSharer);
+        this.domainId = loungeSharer.getLounge().getId();
         this.sendUserId = sendUserId;
         this.receiveUserId = loungeSharer.getUser().getId();
     }
@@ -20,6 +22,11 @@ public class LoungeInviteEvent implements DomainEvent {
         if (loungeSharer.getId() == null) {
             throw new RuntimeException(LOUNGE_NOT_CREATED_EXCEPTION_MESSAGE);
         }
+    }
+
+    @Override
+    public Long getDomainId() {
+        return domainId;
     }
 
     @Override

--- a/src/main/java/com/example/daobe/notification/application/NotificationPublisher.java
+++ b/src/main/java/com/example/daobe/notification/application/NotificationPublisher.java
@@ -1,31 +1,54 @@
 package com.example.daobe.notification.application;
 
+import static com.example.daobe.user.exception.UserExceptionType.NOT_EXIST_USER;
+
 import com.example.daobe.common.domain.DomainEvent;
 import com.example.daobe.notification.application.dto.NotificationPayload;
+import com.example.daobe.notification.domain.Notification;
 import com.example.daobe.notification.domain.NotificationEmitter;
 import com.example.daobe.notification.domain.NotificationEventType;
 import com.example.daobe.notification.domain.repository.EmitterRepository;
+import com.example.daobe.notification.domain.repository.NotificationRepository;
+import com.example.daobe.user.domain.User;
+import com.example.daobe.user.domain.repository.UserRepository;
+import com.example.daobe.user.exception.UserException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 
 @Service
+@Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class NotificationPublisher {
 
+    private final UserRepository userRepository;
     private final EmitterRepository emitterRepository;
+    private final NotificationRepository notificationRepository;
 
     @Async
     @TransactionalEventListener(
             phase = TransactionPhase.AFTER_COMMIT,
             classes = DomainEvent.class
     )
-    public void publish(DomainEvent domainEvent) {
-        String receiveEmitterId = domainEvent.getReceiveUserId().toString();
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void publishEvent(DomainEvent domainEvent) {
+        Long receiveUserId = domainEvent.getReceiveUserId();
+        String receiveEmitterId = receiveUserId.toString();
         NotificationEmitter emitters = emitterRepository.findAllEmitterByUserId(receiveEmitterId);
-        String eventType = NotificationEventType.getEventTypeByDomainEvent(domainEvent);
-        emitters.sendToClient(NotificationPayload.of(domainEvent, eventType));
+        NotificationEventType eventType = NotificationEventType.getEventTypeByDomainEvent(domainEvent);
+        emitters.sendToClient(NotificationPayload.of(domainEvent, eventType.type()));
+
+        User findUser = userRepository.findById(receiveUserId)
+                .orElseThrow(() -> new UserException(NOT_EXIST_USER));
+        Notification newNotification = Notification.builder()
+                .user(findUser)
+                .domainId(domainEvent.getDomainId())
+                .type(eventType)
+                .build();
+        notificationRepository.save(newNotification);
     }
 }

--- a/src/main/java/com/example/daobe/notification/application/NotificationService.java
+++ b/src/main/java/com/example/daobe/notification/application/NotificationService.java
@@ -1,0 +1,46 @@
+package com.example.daobe.notification.application;
+
+import static com.example.daobe.notification.exception.NotificationExceptionType.NOT_EXIST_NOTIFICATION;
+
+import com.example.daobe.notification.application.dto.NotificationInfoResponseDto;
+import com.example.daobe.notification.domain.Notification;
+import com.example.daobe.notification.domain.convert.DomainEventConvertMapper;
+import com.example.daobe.notification.domain.convert.dto.DomainInfo;
+import com.example.daobe.notification.domain.repository.NotificationRepository;
+import com.example.daobe.notification.exception.NotificationException;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class NotificationService {
+
+    private final DomainEventConvertMapper domainEventConvertMapper;
+    private final NotificationRepository notificationRepository;
+
+    public List<NotificationInfoResponseDto> getNotificationList(Long userId) {
+        List<Notification> notificationList = notificationRepository.findByUserId(userId);
+
+        return notificationList.stream()
+                .map((notification) -> {
+                    DomainInfo domainInfo = domainEventConvertMapper.convert(
+                            notification.getType(), notification.getDomainId()
+                    );
+                    return NotificationInfoResponseDto.of(notification, domainInfo);
+                })
+                .toList();
+    }
+
+    @Transactional
+    public void readNotification(Long userId, Long notificationId) {
+        Notification findNotification = notificationRepository.findById(notificationId)
+                .orElseThrow(() -> new NotificationException(NOT_EXIST_NOTIFICATION));
+        findNotification.updateReadStateIfOwnNotification(userId);
+        notificationRepository.save(findNotification);
+    }
+}

--- a/src/main/java/com/example/daobe/notification/application/NotificationSubscribeService.java
+++ b/src/main/java/com/example/daobe/notification/application/NotificationSubscribeService.java
@@ -8,7 +8,7 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 @Service
 @RequiredArgsConstructor
-public class NotificationService {
+public class NotificationSubscribeService {
 
     private static final String DETERMINE = "_";
     private static final Long DEFAULT_TIMEOUT = 44 * 1000L;  // 기본 지속 시간 44초

--- a/src/main/java/com/example/daobe/notification/application/dto/NotificationInfoResponseDto.java
+++ b/src/main/java/com/example/daobe/notification/application/dto/NotificationInfoResponseDto.java
@@ -1,0 +1,37 @@
+package com.example.daobe.notification.application.dto;
+
+import com.example.daobe.notification.domain.Notification;
+import com.example.daobe.notification.domain.convert.dto.DomainInfo;
+import com.example.daobe.user.domain.User;
+
+public record NotificationInfoResponseDto(
+        Long notificationId,
+        String type,
+        boolean isRead,
+        UserInfo author,
+        DomainInfo detail
+) {
+
+    public static NotificationInfoResponseDto of(Notification notification, DomainInfo domainInfo) {
+        return new NotificationInfoResponseDto(
+                notification.getId(),
+                notification.getType().type(),
+                notification.isRead(),
+                UserInfo.of(notification.getUser()),
+                domainInfo
+        );
+    }
+
+    public record UserInfo(
+            Long userId,
+            String nickname
+    ) {
+
+        public static UserInfo of(User user) {
+            return new UserInfo(
+                    user.getId(),
+                    user.getNickname()
+            );
+        }
+    }
+}

--- a/src/main/java/com/example/daobe/notification/application/dto/NotificationPayload.java
+++ b/src/main/java/com/example/daobe/notification/application/dto/NotificationPayload.java
@@ -1,15 +1,18 @@
 package com.example.daobe.notification.application.dto;
 
 import com.example.daobe.common.domain.DomainEvent;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 public record NotificationPayload(
-        Long receiveUserId,
-        Long sendUserId,
-        String eventType
+        @JsonProperty("type_id") Long typeId,
+        @JsonProperty("receive_user_id") Long receiveUserId,
+        @JsonProperty("send_user_id") Long sendUserId,
+        @JsonProperty("event_type") String eventType
 ) {
 
     public static NotificationPayload of(DomainEvent domainEvent, String eventType) {
         return new NotificationPayload(
+                domainEvent.getDomainId(),
                 domainEvent.getReceiveUserId(),
                 domainEvent.getSendUserId(),
                 eventType

--- a/src/main/java/com/example/daobe/notification/domain/Notification.java
+++ b/src/main/java/com/example/daobe/notification/domain/Notification.java
@@ -1,9 +1,14 @@
 package com.example.daobe.notification.domain;
 
+import static com.example.daobe.notification.exception.NotificationExceptionType.IS_NOT_OWN_NOTIFICATION;
+
 import com.example.daobe.common.domain.BaseTimeEntity;
+import com.example.daobe.notification.exception.NotificationException;
 import com.example.daobe.user.domain.User;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -11,7 +16,9 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import java.util.Objects;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -30,9 +37,27 @@ public class Notification extends BaseTimeEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     private User user;
 
-    // 알림 타입 ex) N0001, N0002
-    private String type;
+    @Column(name = "domain_id")
+    private Long domainId;
+
+    @Enumerated(value = EnumType.STRING)
+    private NotificationEventType type;
 
     @Column(name = "is_read")
     private boolean isRead;
+
+    @Builder
+    public Notification(User user, Long domainId, NotificationEventType type) {
+        this.user = user;
+        this.domainId = domainId;
+        this.type = type;
+        this.isRead = false;
+    }
+
+    public void updateReadStateIfOwnNotification(Long userId) {
+        if (Objects.equals(user.getId(), userId)) {
+            isRead = true;
+        }
+        throw new NotificationException(IS_NOT_OWN_NOTIFICATION);
+    }
 }

--- a/src/main/java/com/example/daobe/notification/domain/NotificationEventType.java
+++ b/src/main/java/com/example/daobe/notification/domain/NotificationEventType.java
@@ -25,11 +25,14 @@ public enum NotificationEventType {
         return type;
     }
 
-    public static String getEventTypeByDomainEvent(DomainEvent domainEvent) {
+    public String getClassName() {
+        return eventClass.getName().toLowerCase();
+    }
+
+    public static NotificationEventType getEventTypeByDomainEvent(DomainEvent domainEvent) {
         return Stream.of(NotificationEventType.values())
                 .filter(eventType -> eventType.eventClass.equals(domainEvent.getClass()))
                 .findFirst()
-                .orElseThrow(() -> new NotificationException(NON_MATCH_DOMAIN_EVENT_TYPE))
-                .toString();
+                .orElseThrow(() -> new NotificationException(NON_MATCH_DOMAIN_EVENT_TYPE));
     }
 }

--- a/src/main/java/com/example/daobe/notification/domain/convert/DomainEventConvert.java
+++ b/src/main/java/com/example/daobe/notification/domain/convert/DomainEventConvert.java
@@ -1,0 +1,10 @@
+package com.example.daobe.notification.domain.convert;
+
+import com.example.daobe.notification.domain.convert.dto.DomainInfo;
+
+public interface DomainEventConvert {
+
+    String supportNameToLowerCase();
+
+    DomainInfo convertToDomainInfo(Long domainId);
+}

--- a/src/main/java/com/example/daobe/notification/domain/convert/DomainEventConvertMapper.java
+++ b/src/main/java/com/example/daobe/notification/domain/convert/DomainEventConvertMapper.java
@@ -1,0 +1,28 @@
+package com.example.daobe.notification.domain.convert;
+
+import com.example.daobe.notification.domain.NotificationEventType;
+import com.example.daobe.notification.domain.convert.dto.DomainInfo;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.springframework.stereotype.Component;
+
+@Component
+public class DomainEventConvertMapper {
+
+    private final Map<String, DomainEventConvert> convertMap;
+
+    public DomainEventConvertMapper(List<DomainEventConvert> convertList) {
+        convertMap = new HashMap<>();
+        convertList.forEach(convert -> convertMap.put(convert.supportNameToLowerCase(), convert));
+    }
+
+    public DomainInfo convert(NotificationEventType eventType, Long domainId) {
+        String className = eventType.getClassName();
+        DomainEventConvert converter = convertMap.get(className);
+        if (converter == null) {
+            throw new RuntimeException("일치하는 도메인 이벤트가 없습니다.");
+        }
+        return converter.convertToDomainInfo(domainId);
+    }
+}

--- a/src/main/java/com/example/daobe/notification/domain/convert/LoungeInviteEventConvert.java
+++ b/src/main/java/com/example/daobe/notification/domain/convert/LoungeInviteEventConvert.java
@@ -1,0 +1,32 @@
+package com.example.daobe.notification.domain.convert;
+
+import com.example.daobe.lounge.domain.Lounge;
+import com.example.daobe.lounge.domain.event.LoungeInviteEvent;
+import com.example.daobe.lounge.domain.repository.LoungeRepository;
+import com.example.daobe.notification.domain.convert.dto.DomainInfo;
+import org.springframework.stereotype.Component;
+
+@Component
+public class LoungeInviteEventConvert implements DomainEventConvert {
+
+    private final LoungeRepository loungeRepository;
+
+    public LoungeInviteEventConvert(LoungeRepository loungeRepository) {
+        this.loungeRepository = loungeRepository;
+    }
+
+    @Override
+    public String supportNameToLowerCase() {
+        return LoungeInviteEvent.class.getName().toLowerCase();
+    }
+
+    @Override
+    public DomainInfo convertToDomainInfo(Long domainId) {
+        Lounge findLounge = loungeRepository.findById(domainId)
+                .orElseThrow(() -> new RuntimeException("존재하지 않는 도메인 - 404"));
+        return new DomainInfo(
+                findLounge.getId(),
+                findLounge.getName()
+        );
+    }
+}

--- a/src/main/java/com/example/daobe/notification/domain/convert/ObjetInviteEventConvert.java
+++ b/src/main/java/com/example/daobe/notification/domain/convert/ObjetInviteEventConvert.java
@@ -1,0 +1,32 @@
+package com.example.daobe.notification.domain.convert;
+
+import com.example.daobe.notification.domain.convert.dto.DomainInfo;
+import com.example.daobe.objet.domain.Objet;
+import com.example.daobe.objet.domain.event.ObjetInviteEvent;
+import com.example.daobe.objet.domain.repository.ObjetRepository;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ObjetInviteEventConvert implements DomainEventConvert {
+
+    private final ObjetRepository objetRepository;
+
+    public ObjetInviteEventConvert(ObjetRepository objetRepository) {
+        this.objetRepository = objetRepository;
+    }
+
+    @Override
+    public String supportNameToLowerCase() {
+        return ObjetInviteEvent.class.getName().toLowerCase();
+    }
+
+    @Override
+    public DomainInfo convertToDomainInfo(Long domainId) {
+        Objet findObjet = objetRepository.findById(domainId)
+                .orElseThrow(() -> new RuntimeException("존재하지 않는 도메인 - 404"));
+        return new DomainInfo(
+                findObjet.getObjetId(),
+                findObjet.getName()
+        );
+    }
+}

--- a/src/main/java/com/example/daobe/notification/domain/convert/dto/DomainInfo.java
+++ b/src/main/java/com/example/daobe/notification/domain/convert/dto/DomainInfo.java
@@ -1,0 +1,7 @@
+package com.example.daobe.notification.domain.convert.dto;
+
+public record DomainInfo(
+        Long domainId,
+        String name
+) {
+}

--- a/src/main/java/com/example/daobe/notification/domain/repository/NotificationRepository.java
+++ b/src/main/java/com/example/daobe/notification/domain/repository/NotificationRepository.java
@@ -1,7 +1,10 @@
 package com.example.daobe.notification.domain.repository;
 
 import com.example.daobe.notification.domain.Notification;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
+
+    List<Notification> findByUserId(Long userId);
 }

--- a/src/main/java/com/example/daobe/notification/exception/NotificationExceptionType.java
+++ b/src/main/java/com/example/daobe/notification/exception/NotificationExceptionType.java
@@ -5,7 +5,9 @@ import org.springframework.http.HttpStatus;
 
 public enum NotificationExceptionType implements BaseExceptionType {
     NON_MATCH_DOMAIN_EVENT_TYPE("일치하는 도메인 타입이 없습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
-    IS_NOT_SINGLE_EMITTER("생성된 이미터가 1개가 아닙니다", HttpStatus.INTERNAL_SERVER_ERROR),
+    IS_NOT_SINGLE_EMITTER("생성된 이미터가 1개가 아닙니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+    NOT_EXIST_NOTIFICATION("존재하지 않는 알림입니다.", HttpStatus.NOT_FOUND),
+    IS_NOT_OWN_NOTIFICATION("다른 사용자의 알림입니다.", HttpStatus.FORBIDDEN),
     ;
 
     private final String message;

--- a/src/main/java/com/example/daobe/notification/presentation/NotificationController.java
+++ b/src/main/java/com/example/daobe/notification/presentation/NotificationController.java
@@ -1,0 +1,45 @@
+package com.example.daobe.notification.presentation;
+
+import com.example.daobe.common.response.ApiResponse;
+import com.example.daobe.notification.application.NotificationService;
+import com.example.daobe.notification.application.dto.NotificationInfoResponseDto;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/notification")
+@RequiredArgsConstructor
+public class NotificationController {
+
+    private final NotificationService notificationService;
+
+    // TODO: 페이징 처리
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<NotificationInfoResponseDto>>> getNotificationList(
+            @AuthenticationPrincipal Long userId
+    ) {
+        return ResponseEntity.ok(new ApiResponse<>(
+                "NOTIFICATION_LIST_LOADED_SUCCESS",
+                notificationService.getNotificationList(userId)
+        ));
+    }
+
+    @PatchMapping("/{notificationId}/read")
+    public ResponseEntity<ApiResponse<Void>> readNotification(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long notificationId
+    ) {
+        notificationService.readNotification(userId, notificationId);
+        return ResponseEntity.ok(new ApiResponse<>(
+                "NOTIFICATION_READ_SUCCESS",
+                null
+        ));
+    }
+}

--- a/src/main/java/com/example/daobe/notification/presentation/NotificationSubscribeController.java
+++ b/src/main/java/com/example/daobe/notification/presentation/NotificationSubscribeController.java
@@ -1,6 +1,6 @@
 package com.example.daobe.notification.presentation;
 
-import com.example.daobe.notification.application.NotificationService;
+import com.example.daobe.notification.application.NotificationSubscribeService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -13,7 +13,7 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 @RestController
 @RequestMapping("/api/v1/notification")
 @RequiredArgsConstructor
-public class NotificationController {
+public class NotificationSubscribeController {
 
     private static final String NGINX_X_ACCEL_BUFFERING_HEADER = "X-Accel-Buffering";
     private static final String NO = "no";
@@ -23,13 +23,13 @@ public class NotificationController {
     private static final String CONNECTION = "Connection";
     private static final String CONNECTION_KEEP_ALIVE = "keep-alive";
 
-    private final NotificationService notificationService;
+    private final NotificationSubscribeService notificationSubscribeService;
 
     @GetMapping(value = "/subscribe", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
     public ResponseEntity<SseEmitter> connection(
             @AuthenticationPrincipal Long userId
     ) {
-        SseEmitter emitter = notificationService.subscribeNotification(userId);
+        SseEmitter emitter = notificationSubscribeService.subscribeNotification(userId);
         return ResponseEntity.ok()
                 .header(NGINX_X_ACCEL_BUFFERING_HEADER, NO)
                 .header(KEEP_ALIVE, TIMEOUT + TIMEOUT_VALUE)

--- a/src/main/java/com/example/daobe/objet/domain/event/ObjetInviteEvent.java
+++ b/src/main/java/com/example/daobe/objet/domain/event/ObjetInviteEvent.java
@@ -7,11 +7,13 @@ public class ObjetInviteEvent implements DomainEvent {
 
     private static final String OBJET_NOT_CREATED_EXCEPTION_MESSAGE = "아직 생성되지 않은 오브제 입니다";
 
+    private final Long domainId;
     private final Long sendUserId;
     private final Long receiveUserId;
 
     public ObjetInviteEvent(Long sendUserId, ObjetSharer objetSharer) {
         validate(objetSharer);
+        this.domainId = objetSharer.getObjet().getObjetId();
         this.sendUserId = sendUserId;
         this.receiveUserId = objetSharer.getUser().getId();
     }
@@ -20,6 +22,11 @@ public class ObjetInviteEvent implements DomainEvent {
         if (objetSharer.getId() == null) {
             throw new RuntimeException(OBJET_NOT_CREATED_EXCEPTION_MESSAGE);
         }
+    }
+
+    @Override
+    public Long getDomainId() {
+        return domainId;
     }
 
     @Override


### PR DESCRIPTION
## 📝 개요

- SSE 알림 페이로드 수정 및 알림 저장 및 조회 로직 추가

## ✨ 변경 사항

- 코드나 기능의 주요 변경 사항을 설명합니다.

    - ✨ SSE 알림 전송시 페이로드 수정
    - ✨ 알림 발행시 알림을 저장하는 로직 추가
    - ✨ 특정 사용자에게 발행된 알림을 조회하는 로직 추가

## 🔗 관련 이슈

- 이 PR과 관련된 이슈 번호를 연결합니다. (없으면 생략))
    - closes #123 
