### PR TITLE
유저의 라운지 최대 개수 제한 기능 구현

### DIFF
--- a/src/main/java/com/example/daobe/lounge/application/LoungeSharerService.java
+++ b/src/main/java/com/example/daobe/lounge/application/LoungeSharerService.java
@@ -2,6 +2,7 @@ package com.example.daobe.lounge.application;
 
 import static com.example.daobe.lounge.exception.LoungeExceptionType.ALREADY_INVITED_USER_EXCEPTION;
 import static com.example.daobe.lounge.exception.LoungeExceptionType.INVALID_LOUNGE_SHARER_EXCEPTION;
+import static com.example.daobe.lounge.exception.LoungeExceptionType.MAXIMUM_LOUNGE_LIMIT_EXCEEDED_EXCEPTION;
 
 import com.example.daobe.lounge.domain.Lounge;
 import com.example.daobe.lounge.domain.LoungeSharer;
@@ -17,10 +18,17 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class LoungeSharerService {
 
+    private static final int MAX_LOUNGE_COUNT = 4;
+
     private final ApplicationEventPublisher eventPublisher;
     private final LoungeSharerRepository loungeSharerRepository;
 
     public void createAndSaveLoungeSharer(User user, Lounge lounge) {
+        // 라운지 최대 개수를 초과하는지 검증
+        if (isMaximumCountLounge(user.getId())) {
+            throw new LoungeException(MAXIMUM_LOUNGE_LIMIT_EXCEEDED_EXCEPTION);
+        }
+
         LoungeSharer loungeSharer = LoungeSharer.builder()
                 .user(user)
                 .lounge(lounge)
@@ -29,28 +37,41 @@ public class LoungeSharerService {
     }
 
     public void inviteUser(User user, Lounge lounge, Long inviterId) {
+        validateInvite(user, lounge, inviterId);
+        LoungeSharer loungeSharer = LoungeSharer.builder()
+                .user(user)
+                .lounge(lounge)
+                .build();
+        loungeSharerRepository.save(loungeSharer);
+        eventPublisher.publishEvent(new LoungeInviteEvent(inviterId, loungeSharer));
+    }
+
+    // TODO: 추후 도메인 로직으로 분리
+    private void validateInvite(User user, Lounge lounge, Long inviterId) {
         // 활성 상태인 라운지인지 검증
         lounge.isActiveOrThrow();
 
         // 초대자가 라운지에 소속되어있는지 검증
-        if (isNotExistUserInLounge(inviterId, lounge.getId())) {
+        if (!isExistUserInLounge(inviterId, lounge.getId())) {
             throw new LoungeException(INVALID_LOUNGE_SHARER_EXCEPTION);
         }
 
         // 초대 대상자 라운지 소속 중복 여부 검증
-        if (isNotExistUserInLounge(user.getId(), lounge.getId())) {
-            LoungeSharer loungeSharer = LoungeSharer.builder()
-                    .user(user)
-                    .lounge(lounge)
-                    .build();
-            loungeSharerRepository.save(loungeSharer);
-            eventPublisher.publishEvent(new LoungeInviteEvent(inviterId, loungeSharer));
-            return;
+        if (isExistUserInLounge(user.getId(), lounge.getId())) {
+            throw new LoungeException(ALREADY_INVITED_USER_EXCEPTION);
         }
-        throw new LoungeException(ALREADY_INVITED_USER_EXCEPTION);
+
+        // 라운지 최대 개수를 초과하는지 검증
+        if (isMaximumCountLounge(user.getId())) {
+            throw new LoungeException(MAXIMUM_LOUNGE_LIMIT_EXCEEDED_EXCEPTION);
+        }
     }
 
-    private boolean isNotExistUserInLounge(Long userId, Long loungeId) {
-        return !loungeSharerRepository.existsByUserIdAndLoungeId(userId, loungeId);
+    private boolean isExistUserInLounge(Long userId, Long loungeId) {
+        return loungeSharerRepository.existsByUserIdAndLoungeId(userId, loungeId);
+    }
+
+    private boolean isMaximumCountLounge(Long userId) {
+        return loungeSharerRepository.countActiveLoungeSharerByUserId(userId) == MAX_LOUNGE_COUNT;
     }
 }

--- a/src/main/java/com/example/daobe/lounge/domain/repository/LoungeSharerRepository.java
+++ b/src/main/java/com/example/daobe/lounge/domain/repository/LoungeSharerRepository.java
@@ -14,4 +14,11 @@ public interface LoungeSharerRepository extends JpaRepository<LoungeSharer, Long
     boolean existsByUserIdAndLoungeId(@Param("userId") Long userId, @Param("loungeId") Long loungeId);
 
     List<LoungeSharer> findByLounge_IdAndUser_NicknameContaining(Long loungeId, String nickname);
+
+    @Query("""
+                SELECT COUNT(ls) FROM LoungeSharer ls
+                JOIN ls.lounge l WHERE l.status = 'ACTIVE'
+                AND ls.user.id = :userId
+            """)
+    long countActiveLoungeSharerByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/com/example/daobe/lounge/exception/LoungeExceptionType.java
+++ b/src/main/java/com/example/daobe/lounge/exception/LoungeExceptionType.java
@@ -10,6 +10,7 @@ public enum LoungeExceptionType implements BaseExceptionType {
     INVALID_LOUNGE_SHARER_EXCEPTION("유효하지 않은 라운지 공유자입니다.", HttpStatus.FORBIDDEN),
     ALREADY_INVITED_USER_EXCEPTION("이미 라운지에 소속된 유저입니다.", HttpStatus.METHOD_NOT_ALLOWED),
     ALREADY_DELETED_LOUNGE_EXCEPTION("이미 삭제된 라운지입니다.", HttpStatus.METHOD_NOT_ALLOWED),
+    MAXIMUM_LOUNGE_LIMIT_EXCEEDED_EXCEPTION("라운지 개수는 최대 4개를 초과할 수 없습니다.", HttpStatus.BAD_REQUEST),
     ;
 
     private final String message;


### PR DESCRIPTION
## 📝 개요

```markdown
유저의 라운지 최대 개수 제한 기능 구현
```

## ✨ 변경 사항

<!-- 코드나 기능의 주요 변경 사항을 설명 -->

- ✨ 라운지 최대 개수 예외 추가
- ✨ 활성화된 라운지 중 소속된 라운지 개수 반환 쿼리 추가
- ✨ 라운지 최대 개수 제한 기능 구현

## 🔗 관련 이슈

<!-- 이 PR과 관련된 이슈 번호를 연결 (없으면 생략)) -->

- closed #137
