### PR TITLE
이미지 업로드 로직과 사용자 정보 수정 로직 분리

### DIFF
--- a/src/main/java/com/example/daobe/upload/application/UploadService.java
+++ b/src/main/java/com/example/daobe/upload/application/UploadService.java
@@ -1,6 +1,7 @@
 package com.example.daobe.upload.application;
 
 import com.example.daobe.upload.application.dto.UploadImageResponse;
+import com.example.daobe.upload.application.dto.UploadImageResponseDto;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -12,9 +13,16 @@ public class UploadService {
 
     private final ImageClient imageClient;
 
+    @Deprecated(since = "2024-08-29")
     public UploadImageResponse uploadImage(MultipartFile file) {
         String objectKey = UUID.randomUUID().toString();
         String imageUrl = imageClient.upload(objectKey, file);
         return UploadImageResponse.of(imageUrl);
+    }
+
+    public UploadImageResponseDto upload(MultipartFile file) {
+        String objectKey = UUID.randomUUID().toString();
+        String imageUrl = imageClient.upload(objectKey, file);
+        return UploadImageResponseDto.of(imageUrl);
     }
 }

--- a/src/main/java/com/example/daobe/upload/application/dto/UploadImageResponseDto.java
+++ b/src/main/java/com/example/daobe/upload/application/dto/UploadImageResponseDto.java
@@ -1,0 +1,10 @@
+package com.example.daobe.upload.application.dto;
+
+public record UploadImageResponseDto(
+        String imageUrl
+) {
+
+    public static UploadImageResponseDto of(String imageUrl) {
+        return new UploadImageResponseDto(imageUrl);
+    }
+}

--- a/src/main/java/com/example/daobe/upload/infrastructure/s3/S3ImageClient.java
+++ b/src/main/java/com/example/daobe/upload/infrastructure/s3/S3ImageClient.java
@@ -1,4 +1,4 @@
-package com.example.daobe.upload.s3;
+package com.example.daobe.upload.infrastructure.s3;
 
 import com.example.daobe.common.config.S3Properties;
 import com.example.daobe.upload.application.ImageClient;

--- a/src/main/java/com/example/daobe/upload/infrastructure/s3/S3Uploader.java
+++ b/src/main/java/com/example/daobe/upload/infrastructure/s3/S3Uploader.java
@@ -1,4 +1,4 @@
-package com.example.daobe.upload.s3;
+package com.example.daobe.upload.infrastructure.s3;
 
 import static com.example.daobe.upload.exception.UploadExceptionType.FILE_ENCODE_FAIL;
 import static com.example.daobe.upload.exception.UploadExceptionType.UPLOAD_IMAGE_FAIL;

--- a/src/main/java/com/example/daobe/upload/presentation/UploadController.java
+++ b/src/main/java/com/example/daobe/upload/presentation/UploadController.java
@@ -1,0 +1,30 @@
+package com.example.daobe.upload.presentation;
+
+import com.example.daobe.common.response.ApiResponse;
+import com.example.daobe.upload.application.UploadService;
+import com.example.daobe.upload.application.dto.UploadImageResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequestMapping("/api/v1/uploads")
+@RequiredArgsConstructor
+public class UploadController {
+
+    private final UploadService uploadService;
+
+    @PostMapping("/images")
+    public ResponseEntity<ApiResponse<UploadImageResponseDto>> uploadImage(
+            @RequestParam("file") MultipartFile file
+    ) {
+        return ResponseEntity.ok(new ApiResponse<>(
+                "IMAGE_UPLOAD_SUCCESS",
+                uploadService.upload(file)
+        ));
+    }
+}

--- a/src/main/java/com/example/daobe/user/application/UserService.java
+++ b/src/main/java/com/example/daobe/user/application/UserService.java
@@ -45,7 +45,7 @@ public class UserService {
     }
 
     @Transactional
-    public UpdateProfileResponseDto updateProfile(Long userId, UpdateProfileRequestDto request) {
+    public UpdateProfileResponseDto updateNickname(Long userId, UpdateProfileRequestDto request) {
         User findUser = userRepository.findById(userId)
                 .orElseThrow(() -> new UserException(NOT_EXIST_USER));
 

--- a/src/main/java/com/example/daobe/user/application/UserService.java
+++ b/src/main/java/com/example/daobe/user/application/UserService.java
@@ -4,6 +4,7 @@ import static com.example.daobe.user.exception.UserExceptionType.DUPLICATE_NICKN
 import static com.example.daobe.user.exception.UserExceptionType.NOT_EXIST_USER;
 
 import com.example.daobe.upload.application.UploadService;
+import com.example.daobe.user.application.dto.UpdateProfileRequestDto;
 import com.example.daobe.user.application.dto.UpdateProfileResponseDto;
 import com.example.daobe.user.application.dto.UserInfoResponseDto;
 import com.example.daobe.user.domain.User;
@@ -44,15 +45,16 @@ public class UserService {
     }
 
     @Transactional
-    public UpdateProfileResponseDto updateProfile(Long userId, String nickname) {
+    public UpdateProfileResponseDto updateProfile(Long userId, UpdateProfileRequestDto request) {
         User findUser = userRepository.findById(userId)
                 .orElseThrow(() -> new UserException(NOT_EXIST_USER));
 
-        findUser.updateNickname(nickname);
+        findUser.updateNickname(request.nickname());
         userRepository.save(findUser);
         return UpdateProfileResponseDto.of(findUser);
     }
 
+    @Deprecated(since = "2024-08-29")
     @Transactional
     public UpdateProfileResponseDto updateProfileWithProfileImage(
             Long userId,

--- a/src/main/java/com/example/daobe/user/application/dto/UpdateProfileRequestDto.java
+++ b/src/main/java/com/example/daobe/user/application/dto/UpdateProfileRequestDto.java
@@ -1,7 +1,6 @@
 package com.example.daobe.user.application.dto;
 
 public record UpdateProfileRequestDto(
-        String profileImage,
         String nickname
 ) {
 }

--- a/src/main/java/com/example/daobe/user/presentation/UserController.java
+++ b/src/main/java/com/example/daobe/user/presentation/UserController.java
@@ -80,13 +80,14 @@ public class UserController {
         ));
     }
 
-    public ResponseEntity<ApiResponse<UpdateProfileResponseDto>> updateProfile(
+    @PatchMapping("/nickname")
+    public ResponseEntity<ApiResponse<UpdateProfileResponseDto>> updateNickname(
             @AuthenticationPrincipal Long userId,
             @RequestBody UpdateProfileRequestDto request
     ) {
         return ResponseEntity.ok(new ApiResponse<>(
-                "UPDATE_PROFILE_SUCCESS",
-                userService.updateProfile(userId, request)
+                "UPDATE_NICKNAME_SUCCESS",
+                userService.updateNickname(userId, request)
         ));
     }
 

--- a/src/main/java/com/example/daobe/user/presentation/UserController.java
+++ b/src/main/java/com/example/daobe/user/presentation/UserController.java
@@ -2,6 +2,7 @@ package com.example.daobe.user.presentation;
 
 import com.example.daobe.common.response.ApiResponse;
 import com.example.daobe.user.application.UserService;
+import com.example.daobe.user.application.dto.UpdateProfileRequestDto;
 import com.example.daobe.user.application.dto.UpdateProfileResponseDto;
 import com.example.daobe.user.application.dto.UserInfoResponseDto;
 import java.util.List;
@@ -11,6 +12,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -64,19 +66,28 @@ public class UserController {
         ));
     }
 
-    // FIXME: 이미지 업로드와 사용자 프로필 정보 분리
+
+    @Deprecated(since = "2024-08-29")
     @PatchMapping("/profile")
-    public ResponseEntity<ApiResponse<UpdateProfileResponseDto>> updateProfile(
+    public ResponseEntity<ApiResponse<UpdateProfileResponseDto>> updateProfileWithProfileImage(
             @AuthenticationPrincipal Long userId,
-//            @RequestBody UpdateProfileRequestDto request,
             @RequestParam("nickname") String nickname,
-            @RequestParam(value = "profile_image", required = false) MultipartFile profileImage
+            @RequestParam(value = "profile_image") MultipartFile profileImage
     ) {
         return ResponseEntity.ok(new ApiResponse<>(
                 "UPDATE_SUCCESS",
-                profileImage == null ?
-                        userService.updateProfile(userId, nickname) :
-                        userService.updateProfileWithProfileImage(userId, nickname, profileImage)
+                userService.updateProfileWithProfileImage(userId, nickname, profileImage)
         ));
     }
+
+    public ResponseEntity<ApiResponse<UpdateProfileResponseDto>> updateProfile(
+            @AuthenticationPrincipal Long userId,
+            @RequestBody UpdateProfileRequestDto request
+    ) {
+        return ResponseEntity.ok(new ApiResponse<>(
+                "UPDATE_PROFILE_SUCCESS",
+                userService.updateProfile(userId, request)
+        ));
+    }
+
 }


### PR DESCRIPTION
## 📝 개요

<!-- 이 PR의 목적과 관련된 정보를 간략히 설명합니다. -->

```markdown
기존에 사용자 정보 수정과 이미지 업로드 로직을 한개로 진행하여 `multipart/form-data` 로 받고 있었던 부분 분리
```

## ✨ 변경 사항

<!-- 코드나 기능의 주요 변경 사항을 설명 -->

- ✨ 이미지 업로드 컨트롤러 추가
- ✨ 이미지 업로드와 사용자 정보 수정 로직 분리
- ✨ 기존 로직 유지 (`@Deprecated` 어노테이션 추가)

## 🔗 관련 이슈

<!-- 이 PR과 관련된 이슈 번호를 연결 (없으면 생략)) -->

- closed #144 

