### PR TITLE
사용자 프로필 정보 수정 로직 변경

### DIFF
--- a/src/main/java/com/example/daobe/user/application/UserService.java
+++ b/src/main/java/com/example/daobe/user/application/UserService.java
@@ -49,7 +49,8 @@ public class UserService {
         User findUser = userRepository.findById(userId)
                 .orElseThrow(() -> new UserException(NOT_EXIST_USER));
 
-        findUser.updateNickname(request.nickname());
+        findUser.updateUserInfo(request.nickname(), request.profileUrl());
+
         userRepository.save(findUser);
         return UpdateProfileResponseDto.of(findUser);
     }

--- a/src/main/java/com/example/daobe/user/application/dto/UpdateProfileRequestDto.java
+++ b/src/main/java/com/example/daobe/user/application/dto/UpdateProfileRequestDto.java
@@ -1,6 +1,7 @@
 package com.example.daobe.user.application.dto;
 
 public record UpdateProfileRequestDto(
-        String nickname
+        String nickname,
+        String profileUrl
 ) {
 }

--- a/src/main/java/com/example/daobe/user/domain/User.java
+++ b/src/main/java/com/example/daobe/user/domain/User.java
@@ -54,19 +54,28 @@ public class User extends BaseTimeEntity {
         this.status = UserStatus.ACTIVE_FIRST_LOGIN;
     }
 
-    public void updateNickname(String nickname) {
-        this.nickname = nickname;
-        changeToActiveStatus();
+    public void updateUserInfo(String nickname, String profileUrl) {
+        if (nickname != null) {
+            this.nickname = nickname;
+        }
+        if (profileUrl != null) {
+            this.profileUrl = profileUrl;
+        }
+        updateActiveStatusIfFirstLogin();
     }
 
-    private void changeToActiveStatus() {
+    public void updateNickname(String nickname) {
+        this.nickname = nickname;
+    }
+
+    public void updateProfileUrl(String profileUrl) {
+        this.profileUrl = profileUrl;
+    }
+
+    private void updateActiveStatusIfFirstLogin() {
         if (status.isFirstLogin()) {
             status = UserStatus.ACTIVE;
         }
-    }
-
-    public void updateProfileUrl(String profileImage) {
-        this.profileUrl = profileImage;
     }
 
     public void withdrawWithAddReason(List<String> stringReasonTypeList, String detail) {

--- a/src/main/java/com/example/daobe/user/presentation/UserController.java
+++ b/src/main/java/com/example/daobe/user/presentation/UserController.java
@@ -80,15 +80,14 @@ public class UserController {
         ));
     }
 
-    @PatchMapping("/nickname")
-    public ResponseEntity<ApiResponse<UpdateProfileResponseDto>> updateNickname(
+    @PatchMapping
+    public ResponseEntity<ApiResponse<UpdateProfileResponseDto>> updateProfile(
             @AuthenticationPrincipal Long userId,
             @RequestBody UpdateProfileRequestDto request
     ) {
         return ResponseEntity.ok(new ApiResponse<>(
-                "UPDATE_NICKNAME_SUCCESS",
+                "UPDATE_PROFILE_SUCCESS",
                 userService.updateNickname(userId, request)
         ));
     }
-
 }


### PR DESCRIPTION
## 📝 개요

<!-- 이 PR의 목적과 관련된 정보를 간략히 설명합니다. -->

```markdown
기존에 사용자 정보 수정시 닉네임만 변경할 수 있었던 부분을 닉네임과 프로필 이미지 모두 변경할 수 있도록 수정
```

## ✨ 변경 사항

<!-- 코드나 기능의 주요 변경 사항을 설명 -->

- ✨ 사용자 도메인 로직 수정
- ✨ 프로필 수정 엔드포인트 변경

## 🔗 관련 이슈

<!-- 이 PR과 관련된 이슈 번호를 연결 (없으면 생략)) -->

- closed #147 
