### PR TITLE
레디스 저장소 접근 및 문자열 유틸 클래스 리팩토링

### DIFF
--- a/src/main/java/com/example/daobe/common/utils/DaoStringUtils.java
+++ b/src/main/java/com/example/daobe/common/utils/DaoStringUtils.java
@@ -6,10 +6,6 @@ public class DaoStringUtils {
 
     private static final String DEFAULT_STRING = "";
 
-    public static String concatenateStrings(String... args) {
-        return String.join(DEFAULT_STRING, args);
-    }
-
     /**
      * 여러 개의 인자를 받아서 순서대로 연결한 문자열을 반환합니다.
      *

--- a/src/main/java/com/example/daobe/objet/infrastructure/redis/RedisObjetCallRepository.java
+++ b/src/main/java/com/example/daobe/objet/infrastructure/redis/RedisObjetCallRepository.java
@@ -1,5 +1,6 @@
 package com.example.daobe.objet.infrastructure.redis;
 
+import com.example.daobe.common.utils.DaoStringUtils;
 import com.example.daobe.objet.domain.repository.ObjetCallRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -13,12 +14,12 @@ public class RedisObjetCallRepository implements ObjetCallRepository {
 
     private final RedisTemplate<String, String> redisTemplate;
 
-    // redis 에서 objet:{objetId} 키의 리스트 길이를 조회
     public Long getObjetLength(Long objetId) {
-        return redisTemplate.opsForList().size(key(objetId));
+        String key = generateKey(objetId);
+        return redisTemplate.opsForList().size(key);
     }
 
-    private String key(Long objetId) {
-        return OBJET_PREFIX + objetId;
+    private String generateKey(Long objetId) {
+        return DaoStringUtils.combineToString(OBJET_PREFIX, objetId);
     }
 }

--- a/src/main/java/com/example/daobe/user/infrastructure/redis/RedisUserPokeRepository.java
+++ b/src/main/java/com/example/daobe/user/infrastructure/redis/RedisUserPokeRepository.java
@@ -13,25 +13,24 @@ import org.springframework.stereotype.Component;
 public class RedisUserPokeRepository implements UserPokeRepository {
 
     private static final Long TTL = 180L;  // FIXME: 임시 TTL 3시간 (180분)
-    private static final String SEPARATOR = ":";
-    private static final String POKE_PREFIX = "poke";
+    private static final String POKE_PREFIX = "poke:";
 
     private final RedisTemplate<String, String> redisTemplate;
 
     @Override
     public void save(UserPokeEvent userPokeEvent) {
-        String key = key(userPokeEvent.getSendUserId());
+        String key = generateKey(userPokeEvent.getSendUserId());
         String value = userPokeEvent.getReceiveUserId().toString();
         redisTemplate.opsForValue().set(key, value, TTL, TimeUnit.MINUTES);
     }
 
     @Override
     public boolean existsByUserId(Long userId) {
-        String key = key(userId);
+        String key = generateKey(userId);
         return Boolean.TRUE.equals(redisTemplate.hasKey(key));
     }
 
-    private String key(Long userId) {
-        return DaoStringUtils.combineToString(POKE_PREFIX, SEPARATOR, userId);
+    private String generateKey(Long userId) {
+        return DaoStringUtils.combineToString(POKE_PREFIX, userId);
     }
 }


### PR DESCRIPTION
## 📝 개요

<!-- 이 PR의 목적과 관련된 정보를 간략히 설명합니다. -->

```markdown
각 도메인의 레디스 리포지토리 일관화 및 문자열 유틸 클래스에서 사용하지 않는 메서드 삭제
```

## ✨ 변경 사항

<!-- 코드나 기능의 주요 변경 사항을 설명 -->

- ✨ 인증, 오브제, 사용자 레디스 리포지토리 리팩토링
- ✨ `combineToString()` 삭제

## 🔗 관련 이슈

<!-- 이 PR과 관련된 이슈 번호를 연결 (없으면 생략)) -->

- closed #157 
