### PR TITLE
콕 찌르기 및 알림 읽기시 발생한 오류 수정

### DIFF
--- a/src/main/java/com/example/daobe/notification/domain/Notification.java
+++ b/src/main/java/com/example/daobe/notification/domain/Notification.java
@@ -60,9 +60,9 @@ public class Notification extends BaseTimeEntity {
     }
 
     public void updateReadStateIfOwnNotification(Long userId) {
-        if (Objects.equals(receiveUser.getId(), userId)) {
-            isRead = true;
+        if (!Objects.equals(receiveUser.getId(), userId)) {
+            throw new NotificationException(IS_NOT_OWN_NOTIFICATION);
         }
-        throw new NotificationException(IS_NOT_OWN_NOTIFICATION);
+        isRead = true;
     }
 }

--- a/src/main/java/com/example/daobe/user/application/UserService.java
+++ b/src/main/java/com/example/daobe/user/application/UserService.java
@@ -65,7 +65,13 @@ public class UserService {
             throw new UserException(UserExceptionType.ALREADY_POKE);
         }
 
-        UserPokeEvent userPokeEvent = new UserPokeEvent(request.userId(), userId);
+        Long receiveUserId = request.userId();
+        boolean isExistUser = userRepository.existsById(receiveUserId);
+        if (!isExistUser) {
+            throw new UserException(NOT_EXIST_USER);
+        }
+
+        UserPokeEvent userPokeEvent = new UserPokeEvent(userId, receiveUserId);
         userPokeRepository.save(userPokeEvent);
 
         eventPublisher.publishEvent(userPokeEvent);


### PR DESCRIPTION
## 📝 개요

<!-- 이 PR의 목적과 관련된 정보를 간략히 설명합니다. -->

```markdown
콕 찌르기시 `senderId`와 `receiveId` 가 반대로 된 문제 해결 및 알림 읽기시 403 응답이 오던 문제 해결
```

## ✨ 변경 사항

<!-- 코드나 기능의 주요 변경 사항을 설명 -->

- ✨ 콕 찌르기시 존재하는 사용자인지 확인하는 로직 추가
- ✨ `senderId`와 `receiveId` 가 반대로 설정된 문제 해결
- ✨ 알림 읽기시 403 응답 수정

## 🔗 관련 이슈

<!-- 이 PR과 관련된 이슈 번호를 연결 (없으면 생략)) -->

- closed #159 

## ℹ️ 참고 사항

<!-- 리뷰어가 알 필요가 있는 추가 정보나 문서, 참고 링크를 포함 -->

- 추후에 이벤트 도메인 생성시 Builder 패턴 적용 예정
