### PR TITLE
활성 상태가 아닌 라운지 조회시 404 예외 던지도록 수정

### DIFF
--- a/src/main/java/com/example/daobe/lounge/exception/LoungeExceptionType.java
+++ b/src/main/java/com/example/daobe/lounge/exception/LoungeExceptionType.java
@@ -5,7 +5,7 @@ import org.springframework.http.HttpStatus;
 
 public enum LoungeExceptionType implements BaseExceptionType {
     INVALID_LOUNGE_ID_EXCEPTION("유효하지 않은 라운지 ID입니다.", HttpStatus.NOT_FOUND),
-    NOT_ACTIVE_LOUNGE_EXCEPTION("활성 상태가 아닌 라운지입니다.", HttpStatus.METHOD_NOT_ALLOWED),
+    NOT_ACTIVE_LOUNGE_EXCEPTION("활성 상태가 아닌 라운지입니다.", HttpStatus.NOT_FOUND),
     INVALID_LOUNGE_OWNER_EXCEPTION("유효하지 않은 라운지 주인입니다.", HttpStatus.FORBIDDEN),
     INVALID_LOUNGE_SHARER_EXCEPTION("유효하지 않은 라운지 공유자입니다.", HttpStatus.FORBIDDEN),
     ALREADY_INVITED_USER_EXCEPTION("이미 라운지에 소속된 유저입니다.", HttpStatus.METHOD_NOT_ALLOWED),


### PR DESCRIPTION
## 📝 개요

<!-- 이 PR의 목적과 관련된 정보를 간략히 설명합니다. -->

```markdown
활성 상태가 아닌 라운지 조회시 404 예외 던지도록 수정
```

## ✨ 변경 사항

<!-- 코드나 기능의 주요 변경 사항을 설명 -->

- ✨ METHOD_NOT_ALLOWED -> NOT_FOUND

## 🔗 관련 이슈

<!-- 이 PR과 관련된 이슈 번호를 연결 (없으면 생략)) -->

- #131 
