### PR TITLE
사용자 도메인 이벤트 및 이벤트 발행 로직 추가

### DIFF
--- a/src/main/java/com/example/daobe/user/application/UserService.java
+++ b/src/main/java/com/example/daobe/user/application/UserService.java
@@ -49,7 +49,7 @@ public class UserService {
     }
 
     @Transactional
-    public UpdateProfileResponseDto updateNickname(Long userId, UpdateProfileRequestDto request) {
+    public UpdateProfileResponseDto updateProfile(Long userId, UpdateProfileRequestDto request) {
         User findUser = userRepository.findById(userId)
                 .orElseThrow(() -> new UserException(NOT_EXIST_USER));
 
@@ -77,7 +77,7 @@ public class UserService {
         eventPublisher.publishEvent(userPokeEvent);
     }
 
-    // FIXME: External Service
+    // FIXME: EDA 기반으로 수정
     public User getUserById(Long userId) {
         return userRepository.findById(userId)
                 .orElseThrow(() -> new UserException(NOT_EXIST_USER));

--- a/src/main/java/com/example/daobe/user/application/UserService.java
+++ b/src/main/java/com/example/daobe/user/application/UserService.java
@@ -10,6 +10,7 @@ import com.example.daobe.user.application.dto.UserPokeRequestDto;
 import com.example.daobe.user.domain.User;
 import com.example.daobe.user.domain.UserStatus;
 import com.example.daobe.user.domain.event.UserPokeEvent;
+import com.example.daobe.user.domain.event.UserUpdateEvent;
 import com.example.daobe.user.domain.repository.UserPokeRepository;
 import com.example.daobe.user.domain.repository.UserRepository;
 import com.example.daobe.user.exception.UserException;
@@ -52,10 +53,11 @@ public class UserService {
     public UpdateProfileResponseDto updateProfile(Long userId, UpdateProfileRequestDto request) {
         User findUser = userRepository.findById(userId)
                 .orElseThrow(() -> new UserException(NOT_EXIST_USER));
-
         findUser.updateUserInfo(request.nickname(), request.profileUrl());
 
         userRepository.save(findUser);
+        eventPublisher.publishEvent(UserUpdateEvent.of(findUser));
+
         return UpdateProfileResponseDto.of(findUser);
     }
 

--- a/src/main/java/com/example/daobe/user/domain/event/UserCreateEvent.java
+++ b/src/main/java/com/example/daobe/user/domain/event/UserCreateEvent.java
@@ -1,0 +1,18 @@
+package com.example.daobe.user.domain.event;
+
+import com.example.daobe.user.domain.User;
+
+public record UserCreateEvent(
+        Long userId,
+        String nickname,
+        String profileUrl
+) {
+
+    public static UserCreateEvent of(User user) {
+        return new UserCreateEvent(
+                user.getId(),
+                user.getNickname(),
+                user.getProfileUrl()
+        );
+    }
+}

--- a/src/main/java/com/example/daobe/user/domain/event/UserUpdateEvent.java
+++ b/src/main/java/com/example/daobe/user/domain/event/UserUpdateEvent.java
@@ -1,0 +1,18 @@
+package com.example.daobe.user.domain.event;
+
+import com.example.daobe.user.domain.User;
+
+public record UserUpdateEvent(
+        Long userId,
+        String nickname,
+        String profileUrl
+) {
+
+    public static UserUpdateEvent of(User user) {
+        return new UserUpdateEvent(
+                user.getId(),
+                user.getNickname(),
+                user.getProfileUrl()
+        );
+    }
+}

--- a/src/main/java/com/example/daobe/user/presentation/UserController.java
+++ b/src/main/java/com/example/daobe/user/presentation/UserController.java
@@ -74,7 +74,7 @@ public class UserController {
     ) {
         return ResponseEntity.ok(new ApiResponse<>(
                 "UPDATE_PROFILE_SUCCESS",
-                userService.updateNickname(userId, request)
+                userService.updateProfile(userId, request)
         ));
     }
 


### PR DESCRIPTION
## 📝 개요

<!-- 이 PR의 목적과 관련된 정보를 간략히 설명합니다. -->

```markdown
스프링 이벤트를 통해 도메인간의 의존성을 분리하기 위해, 사용자 생성 및 수정 이벤트 클래스 및 발행 로직 추가
```

## ✨ 변경 사항

<!-- 코드나 기능의 주요 변경 사항을 설명 -->

- ✨ 사용자 생성 이벤트 추가
- ✨ 사용자 업데이트 이벤트 추가

## 🔗 관련 이슈

<!-- 이 PR과 관련된 이슈 번호를 연결 (없으면 생략)) -->

- closed #176 
