### PR TITLE
채팅 메시지 유저 데이터 동기화 기능 추가

### DIFF
--- a/docker/init.js
+++ b/docker/init.js
@@ -1,2 +1,3 @@
 db = db.getSiblingDB('dao-local-db');
 db.createCollection('chat_message');
+db.createCollection('chat_user');

--- a/src/main/java/com/example/daobe/chat/application/dto/ChatMessageDto.java
+++ b/src/main/java/com/example/daobe/chat/application/dto/ChatMessageDto.java
@@ -1,6 +1,7 @@
 package com.example.daobe.chat.application.dto;
 
 import com.example.daobe.chat.domain.ChatMessage;
+import com.example.daobe.chat.domain.ChatUser;
 import java.time.LocalDateTime;
 
 public record ChatMessageDto(
@@ -13,14 +14,14 @@ public record ChatMessageDto(
         String message,
         LocalDateTime createdAt
 ) {
-    public static ChatMessageDto of(ChatMessage message) {
+    public static ChatMessageDto of(ChatMessage message, ChatUser sender) {
         return new ChatMessageDto(
                 message.getId(),
                 message.getType(),
                 message.getRoomToken(),
                 message.getSenderId(),
-                message.getSender(),
-                message.getSenderProfileUrl(),
+                sender.getNickname(),
+                sender.getProfileUrl(),
                 message.getMessage(),
                 message.getCreatedAt()
         );

--- a/src/main/java/com/example/daobe/chat/application/event/ChatUserEventListener.java
+++ b/src/main/java/com/example/daobe/chat/application/event/ChatUserEventListener.java
@@ -1,2 +1,36 @@
-package com.example.daobe.chat.application.event;public class ChatUserEventListener {
+package com.example.daobe.chat.application.event;
+
+import com.example.daobe.chat.domain.ChatUser;
+import com.example.daobe.chat.domain.repository.ChatUserRepository;
+import com.example.daobe.user.domain.event.UserCreateEvent;
+import com.example.daobe.user.domain.event.UserUpdateEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ChatUserEventListener {
+
+    private final ChatUserRepository chatUserRepository;
+
+    @EventListener
+    public void handleUserCreated(UserCreateEvent event) {
+        ChatUser chatUser = ChatUser.builder()
+                .userId(event.userId())
+                .nickname(event.nickname())
+                .profileUrl(event.profileUrl())
+                .build();
+        chatUserRepository.save(chatUser);
+    }
+
+    @EventListener
+    public void handleUserUpdated(UserUpdateEvent event) {
+        ChatUser findUser = chatUserRepository.findByUserId(event.userId())
+                .orElseThrow(() -> new RuntimeException("NOT_EXISTS_USER_EXCEPTION"));
+        findUser.updateUserInfo(event.nickname(), event.profileUrl());
+        chatUserRepository.save(findUser);
+    }
 }

--- a/src/main/java/com/example/daobe/chat/application/event/ChatUserEventListener.java
+++ b/src/main/java/com/example/daobe/chat/application/event/ChatUserEventListener.java
@@ -1,0 +1,2 @@
+package com.example.daobe.chat.application.event;public class ChatUserEventListener {
+}

--- a/src/main/java/com/example/daobe/chat/domain/ChatMessage.java
+++ b/src/main/java/com/example/daobe/chat/domain/ChatMessage.java
@@ -34,24 +34,15 @@ public class ChatMessage {
     @Field("sender_id")
     private Long senderId;
 
-    @Field("sender")
-    private String sender;
-
-    @Field("sender_profile_url")
-    private String senderProfileUrl;
-
     @Field("created_at")
     @CreatedDate
     private LocalDateTime createdAt;
 
     @Builder
-    public ChatMessage(String roomToken, MessageType type, String message, Long senderId, String sender,
-                       String senderProfileUrl) {
+    public ChatMessage(String roomToken, MessageType type, String message, Long senderId) {
         this.roomToken = roomToken;
         this.type = type.name();
         this.message = message;
         this.senderId = senderId;
-        this.sender = sender;
-        this.senderProfileUrl = senderProfileUrl;
     }
 }

--- a/src/main/java/com/example/daobe/chat/domain/ChatUser.java
+++ b/src/main/java/com/example/daobe/chat/domain/ChatUser.java
@@ -1,2 +1,45 @@
-package com.example.daobe.chat.domain;public class ChatUser {
+package com.example.daobe.chat.domain;
+
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.mongodb.core.index.Indexed;
+import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.mapping.Field;
+
+@Getter
+@Document(collection = "chat_user")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChatUser {
+
+    @Id
+    private String id;
+
+    @Indexed(unique = true)
+    @Field("user_id")
+    private Long userId;
+
+    @Field("nickname")
+    private String nickname;
+
+    @Field("profile_url")
+    private String profileUrl;
+
+    @Builder
+    public ChatUser(Long userId, String nickname, String profileUrl) {
+        this.userId = userId;
+        this.nickname = nickname;
+        this.profileUrl = profileUrl;
+    }
+
+    public void updateUserInfo(String nickname, String profileUrl) {
+        if (nickname != null) {
+            this.nickname = nickname;
+        }
+        if (profileUrl != null) {
+            this.profileUrl = profileUrl;
+        }
+    }
 }

--- a/src/main/java/com/example/daobe/chat/domain/ChatUser.java
+++ b/src/main/java/com/example/daobe/chat/domain/ChatUser.java
@@ -1,0 +1,2 @@
+package com.example.daobe.chat.domain;public class ChatUser {
+}

--- a/src/main/java/com/example/daobe/chat/domain/repository/ChatUserRepository.java
+++ b/src/main/java/com/example/daobe/chat/domain/repository/ChatUserRepository.java
@@ -1,0 +1,2 @@
+package com.example.daobe.chat.domain.repository;public interface ChatUserRepository {
+}

--- a/src/main/java/com/example/daobe/chat/domain/repository/ChatUserRepository.java
+++ b/src/main/java/com/example/daobe/chat/domain/repository/ChatUserRepository.java
@@ -1,2 +1,14 @@
-package com.example.daobe.chat.domain.repository;public interface ChatUserRepository {
+package com.example.daobe.chat.domain.repository;
+
+import com.example.daobe.chat.domain.ChatUser;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+public interface ChatUserRepository extends MongoRepository<ChatUser, String> {
+
+    Optional<ChatUser> findByUserId(Long userId);
+
+    List<ChatUser> findAllByUserIdIn(Set<Long> userIds);
 }


### PR DESCRIPTION
## 📝 개요

```markdown
채팅 메시지 유저 데이터 동기화 기능 추가
```

## ✨ 변경 사항

<!-- 코드나 기능의 주요 변경 사항을 설명 -->

- ✨ 채팅 메시지 유저 데이터 저장을 위한 MongoDB 컬렉션 추가
- ✨ 채팅 메시지 데이터 및 DTO 구조 변경
- ✨ 래팅방 유저 데이터 생성/수정 이벤트 리스너 추가
- ✨ 채팅 메시지 유저 동기화 기능 추가

## 🔗 관련 이슈

<!-- 이 PR과 관련된 이슈 번호를 연결 (없으면 생략)) -->

- closed #161 
