### PR TITLE
사용자 명칭 일관화 및 토큰 검증 로직 리팩토링

### DIFF
--- a/src/main/java/com/example/daobe/auth/application/AuthService.java
+++ b/src/main/java/com/example/daobe/auth/application/AuthService.java
@@ -1,7 +1,6 @@
 package com.example.daobe.auth.application;
 
 import static com.example.daobe.auth.exception.AuthExceptionType.INVALID_TOKEN;
-import static com.example.daobe.auth.exception.AuthExceptionType.UN_MATCH_USER_INFO;
 
 import com.example.daobe.auth.application.dto.TokenResponseDto;
 import com.example.daobe.auth.application.dto.WithdrawRequestDto;
@@ -63,9 +62,7 @@ public class AuthService {
         Token findToken = tokenRepository.findByTokenId(tokenId)
                 .orElseThrow(() -> new AuthException(INVALID_TOKEN));
 
-        if (!findToken.isMatchUserId(userId)) {
-            throw new AuthException(UN_MATCH_USER_INFO);
-        }
+        findToken.isMatchOrElseThrow(userId);
 
         tokenRepository.deleteByTokenId(findToken.getTokenId());
     }
@@ -75,9 +72,7 @@ public class AuthService {
         Token findToken = tokenRepository.findByTokenId(tokenId)
                 .orElseThrow(() -> new AuthException(INVALID_TOKEN));
 
-        if (!findToken.isMatchUserId(userId)) {
-            throw new AuthException(UN_MATCH_USER_INFO);
-        }
+        findToken.isMatchOrElseThrow(userId);
 
         tokenRepository.deleteByTokenId(findToken.getTokenId());
 

--- a/src/main/java/com/example/daobe/auth/application/AuthService.java
+++ b/src/main/java/com/example/daobe/auth/application/AuthService.java
@@ -32,11 +32,11 @@ public class AuthService {
                 .orElseGet(() -> saveAndPublishEvent(oAuthId));
 
         Token newToken = Token.builder()
-                .memberId(findUser.getId())
+                .userId(findUser.getId())
                 .build();
         tokenRepository.save(newToken);
 
-        String accessToken = tokenProvider.generatedAccessToken(newToken.getMemberId());
+        String accessToken = tokenProvider.generatedAccessToken(newToken.getUserId());
         String refreshToken = tokenProvider.generatedRefreshToken(newToken.getTokenId());
         return TokenResponseDto.of(accessToken, refreshToken);
     }
@@ -48,12 +48,12 @@ public class AuthService {
 
         tokenRepository.deleteByTokenId(findToken.getTokenId());
         Token newToken = Token.builder()
-                .memberId(findToken.getMemberId())
+                .userId(findToken.getUserId())
                 .build();
 
         tokenRepository.save(newToken);
 
-        String accessToken = tokenProvider.generatedAccessToken(newToken.getMemberId());
+        String accessToken = tokenProvider.generatedAccessToken(newToken.getUserId());
         String refreshToken = tokenProvider.generatedRefreshToken(newToken.getTokenId());
         return TokenResponseDto.of(accessToken, refreshToken);
     }
@@ -63,7 +63,7 @@ public class AuthService {
         Token findToken = tokenRepository.findByTokenId(tokenId)
                 .orElseThrow(() -> new AuthException(INVALID_TOKEN));
 
-        if (!findToken.isMatchMemberId(userId)) {
+        if (!findToken.isMatchUserId(userId)) {
             throw new AuthException(UN_MATCH_USER_INFO);
         }
 
@@ -75,7 +75,7 @@ public class AuthService {
         Token findToken = tokenRepository.findByTokenId(tokenId)
                 .orElseThrow(() -> new AuthException(INVALID_TOKEN));
 
-        if (!findToken.isMatchMemberId(userId)) {
+        if (!findToken.isMatchUserId(userId)) {
             throw new AuthException(UN_MATCH_USER_INFO);
         }
 

--- a/src/main/java/com/example/daobe/auth/application/TokenProvider.java
+++ b/src/main/java/com/example/daobe/auth/application/TokenProvider.java
@@ -2,7 +2,7 @@ package com.example.daobe.auth.application;
 
 public interface TokenProvider {
 
-    String generatedAccessToken(Long memberId);
+    String generatedAccessToken(Long userId);
 
     String generatedRefreshToken(String tokenId);
 }

--- a/src/main/java/com/example/daobe/auth/domain/Token.java
+++ b/src/main/java/com/example/daobe/auth/domain/Token.java
@@ -1,5 +1,8 @@
 package com.example.daobe.auth.domain;
 
+import static com.example.daobe.auth.exception.AuthExceptionType.UN_MATCH_USER_INFO;
+
+import com.example.daobe.auth.exception.AuthException;
 import java.util.Objects;
 import java.util.UUID;
 import lombok.AccessLevel;
@@ -20,8 +23,10 @@ public class Token {
         this.tokenId = generatedTokenId();
     }
 
-    public boolean isMatchUserId(Long userId) {
-        return Objects.equals(userId, this.userId);
+    public void isMatchOrElseThrow(Long userId) {
+        if (!Objects.equals(userId, this.userId)) {
+            throw new AuthException(UN_MATCH_USER_INFO);
+        }
     }
 
     private String generatedTokenId() {

--- a/src/main/java/com/example/daobe/auth/domain/Token.java
+++ b/src/main/java/com/example/daobe/auth/domain/Token.java
@@ -11,17 +11,17 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Token {
 
-    private Long memberId;
+    private Long userId;
     private String tokenId;
 
     @Builder
-    public Token(Long memberId) {
-        this.memberId = memberId;
+    public Token(Long userId) {
+        this.userId = userId;
         this.tokenId = generatedTokenId();
     }
 
-    public boolean isMatchMemberId(Long memberId) {
-        return Objects.equals(memberId, this.memberId);
+    public boolean isMatchUserId(Long userId) {
+        return Objects.equals(userId, this.userId);
     }
 
     private String generatedTokenId() {

--- a/src/main/java/com/example/daobe/auth/infrastructure/jwt/JwtExtractor.java
+++ b/src/main/java/com/example/daobe/auth/infrastructure/jwt/JwtExtractor.java
@@ -18,7 +18,7 @@ import org.springframework.stereotype.Component;
 @Component
 public class JwtExtractor implements TokenExtractor {
 
-    private static final String MEMBER_ID = "member_id";
+    private static final String USER_ID = "user_id";
     private static final String TOKEN_ID = "token_id";
     private static final String ACCESS_TOKEN = "access_token";
     private static final String REFRESH_TOKEN = "refresh_token";
@@ -34,7 +34,7 @@ public class JwtExtractor implements TokenExtractor {
 
     @Override
     public Long extractAccessToken(String token) {
-        return extract(token, ACCESS_TOKEN, MEMBER_ID, Long.class);
+        return extract(token, ACCESS_TOKEN, USER_ID, Long.class);
     }
 
     @Override

--- a/src/main/java/com/example/daobe/auth/infrastructure/jwt/JwtProvider.java
+++ b/src/main/java/com/example/daobe/auth/infrastructure/jwt/JwtProvider.java
@@ -13,7 +13,7 @@ import org.springframework.stereotype.Component;
 @Component
 public class JwtProvider implements TokenProvider {
 
-    private static final String MEMBER_ID = "member_id";
+    private static final String USER_ID = "user_id";
     private static final String TOKEN_ID = "token_id";
     private static final String ACCESS_TOKEN = "access_token";
     private static final String REFRESH_TOKEN = "refresh_token";
@@ -29,8 +29,8 @@ public class JwtProvider implements TokenProvider {
     }
 
     @Override
-    public String generatedAccessToken(Long memberId) {
-        Claims claims = generatedClaims(MEMBER_ID, memberId);
+    public String generatedAccessToken(Long userId) {
+        Claims claims = generatedClaims(USER_ID, userId);
         return generatedToken(claims, ACCESS_TOKEN, jwtProperties.accessExpired());
     }
 

--- a/src/main/java/com/example/daobe/auth/infrastructure/security/JwtAuthenticationProvider.java
+++ b/src/main/java/com/example/daobe/auth/infrastructure/security/JwtAuthenticationProvider.java
@@ -24,8 +24,8 @@ public class JwtAuthenticationProvider implements AuthenticationProvider {
 
         //  access_token 검증 결과를 가지고 토큰 객체를 만들어 반환
         try {
-            Long memberId = jwtExtractor.extractAccessToken(accessToken);
-            return JwtAuthenticationToken.afterOf(memberId);
+            Long userId = jwtExtractor.extractAccessToken(accessToken);
+            return JwtAuthenticationToken.afterOf(userId);
         } catch (RuntimeException ex) {
             throw new SecurityException(INVALID_TOKEN);
         }

--- a/src/main/java/com/example/daobe/auth/infrastructure/security/JwtAuthenticationToken.java
+++ b/src/main/java/com/example/daobe/auth/infrastructure/security/JwtAuthenticationToken.java
@@ -27,8 +27,8 @@ public class JwtAuthenticationToken extends UsernamePasswordAuthenticationToken 
     }
 
     // 인증 후의 토큰 객체 생성
-    public static JwtAuthenticationToken afterOf(Long memberId) {
-        return new JwtAuthenticationToken(memberId, "", null);
+    public static JwtAuthenticationToken afterOf(Long userId) {
+        return new JwtAuthenticationToken(userId, "", null);
     }
 
     public String getAccessToken() {


### PR DESCRIPTION
## 📝 개요

<!-- 이 PR의 목적과 관련된 정보를 간략히 설명합니다. -->

```markdown
`member` 와 `user` 를 혼용하여 사용하던 부분 수정 및 토큰 검증 로직 리팩토링
```

## ✨ 변경 사항

<!-- 코드나 기능의 주요 변경 사항을 설명 -->

- ✨ 사용자를 `user` 로 통일
- ✨ 토큰 유효성 검사 로직 리팩토링

## 🔗 관련 이슈

<!-- 이 PR과 관련된 이슈 번호를 연결 (없으면 생략)) -->

- closed #150 
