### PR TITLE
사용자 아이디가 null 값인 경우 예외 처리 추가

### DIFF
--- a/src/main/java/com/example/daobe/auth/infrastructure/jwt/JwtExtractor.java
+++ b/src/main/java/com/example/daobe/auth/infrastructure/jwt/JwtExtractor.java
@@ -47,6 +47,11 @@ public class JwtExtractor implements TokenExtractor {
         String subject = claims.getSubject();
 
         if (subject.equals(expectedTokenType)) {
+            T t = claims.get(claimKey, T);
+            // FIXME: hotfix 라서 리팩토링 진행해야함
+            if (t == null) {
+                throw new AuthException(INVALID_TOKEN_TYPE);
+            }
             return claims.get(claimKey, T);
         }
         throw new AuthException(INVALID_TOKEN_TYPE);


### PR DESCRIPTION
## 📝 개요

<!-- 이 PR의 목적과 관련된 정보를 간략히 설명합니다. -->

```markdown
이전에 access token 페이로드가 `member_id` 에서 `user_id` 로 변경 하여 이전 access token 값을 추출 할 때, null 값이 반환되어 500 응답이 오던 오류 수정
```

## ✨ 변경 사항

<!-- 코드나 기능의 주요 변경 사항을 설명 -->

- ✨ access token 에 저장된 사용자 정보가 null 값이 경우 예외 처리
