### PR TITLE
회원탈퇴 후 재가입시 사용자 상태가 수정되지 않던 문제 수정

### DIFF
--- a/src/main/java/com/example/daobe/auth/application/AuthService.java
+++ b/src/main/java/com/example/daobe/auth/application/AuthService.java
@@ -7,28 +7,26 @@ import com.example.daobe.auth.application.dto.WithdrawRequestDto;
 import com.example.daobe.auth.domain.Token;
 import com.example.daobe.auth.domain.repository.TokenRepository;
 import com.example.daobe.auth.exception.AuthException;
+import com.example.daobe.user.application.UserService;
 import com.example.daobe.user.domain.User;
-import com.example.daobe.user.domain.event.UserCreateEvent;
 import com.example.daobe.user.domain.repository.UserRepository;
 import com.example.daobe.user.exception.UserException;
 import com.example.daobe.user.exception.UserExceptionType;
 import lombok.RequiredArgsConstructor;
-import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
 public class AuthService {
 
+    private final UserService userService;
     private final TokenProvider tokenProvider;
     private final TokenExtractor tokenExtractor;
     private final UserRepository userRepository;
     private final TokenRepository tokenRepository;
-    private final ApplicationEventPublisher eventPublisher;
 
     public TokenResponseDto loginOrRegister(String oAuthId) {
-        User findUser = userRepository.findByKakaoId(oAuthId)
-                .orElseGet(() -> saveAndPublishEvent(oAuthId));
+        User findUser = userService.getOrRegisterByOAuthId(oAuthId);
 
         Token newToken = Token.builder()
                 .userId(findUser.getId())
@@ -80,11 +78,5 @@ public class AuthService {
                 .orElseThrow(() -> new UserException(UserExceptionType.NOT_EXIST_USER));
         findUser.withdrawWithAddReason(request.reasonTypeList(), request.detail());
         userRepository.save(findUser);
-    }
-
-    private User saveAndPublishEvent(String oAuthId) {
-        User newUser = userRepository.save(User.builder().kakaoId(oAuthId).build());
-        eventPublisher.publishEvent(UserCreateEvent.of(newUser));
-        return newUser;
     }
 }

--- a/src/main/java/com/example/daobe/user/domain/User.java
+++ b/src/main/java/com/example/daobe/user/domain/User.java
@@ -78,6 +78,18 @@ public class User extends BaseTimeEntity {
         }
     }
 
+    public boolean isDeletedUser() {
+        return status == UserStatus.DELETED;
+    }
+
+    public void activateFirstLogin() {
+        updateStatus(UserStatus.ACTIVE_FIRST_LOGIN);
+    }
+
+    private void updateStatus(UserStatus status) {
+        this.status = status;
+    }
+
     public void withdrawWithAddReason(List<String> stringReasonTypeList, String detail) {
         this.reasons = stringReasonTypeList.stream()
                 .map(ReasonType::getReasonTypeByString)


### PR DESCRIPTION
## 📝 개요

<!-- 이 PR의 목적과 관련된 정보를 간략히 설명합니다. -->

```markdown
회원탈퇴 후 다시 OAuth 가입시 사용자 상태가 여전히 삭제 상태인 문제 해결
```

## ✨ 변경 사항

<!-- 코드나 기능의 주요 변경 사항을 설명 -->

- ✨ 삭제 상태인 경우 사용자 상태를 `IS_FIRST_LOGIN` 상태로 변경되도록 수정

## 🔗 관련 이슈

<!-- 이 PR과 관련된 이슈 번호를 연결 (없으면 생략)) -->

- closed #204 
