### PR TITLE
새로운 사용자 생성 이벤트에서 id 값이 null 인 오류 수정

### DIFF
--- a/.github/workflows/backend-prod-cd.yml
+++ b/.github/workflows/backend-prod-cd.yml
@@ -1,4 +1,4 @@
-name: 백엔드 DEV CD
+name: 백엔드 PROD CD
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
## 📝 개요

<!-- 이 PR의 목적과 관련된 정보를 간략히 설명합니다. -->

```markdown
OAuth 인증을 통해 새로운 사용자가 생성될 때 발급되는 이벤트가 영속화 전에 발급되어 id 값이 null 인 오류 수정
```

## ✨ 변경 사항

<!-- 코드나 기능의 주요 변경 사항을 설명 -->

- ✨ 새로운 사용자 저장후 생성 이벤트를 발급하도록 수정
