### PR TITLE
개발, 운영 서버 프로퍼티 설정 수정 및 라운지 공유자 테이블에 컬럼 추가

### DIFF
--- a/src/main/resources/db/migration/V2__add_status_in_lounges_sharers.sql
+++ b/src/main/resources/db/migration/V2__add_status_in_lounges_sharers.sql
@@ -1,0 +1,2 @@
+ALTER TABLE lounges_sharers
+    ADD COLUMN status varchar(255);


### PR DESCRIPTION
## 📝 개요

<!-- 이 PR의 목적과 관련된 정보를 간략히 설명합니다. -->

```markdown
기존에 최대 사진 사이즈 제한이 1MB 였던 부분을 25MB 로 수정 및 라운지 공유자 테이블에서 status 컬럼 추가
```

## ✨ 변경 사항

<!-- 코드나 기능의 주요 변경 사항을 설명 -->

- ✨ 개발 및 운영 서버의 최대 요청 파일 사이즈 수정 1MB -> 25MB
- ✨ 라운지 공유자 테이블에서 `status` 컬럼 추가

## 🔗 관련 이슈

<!-- 이 PR과 관련된 이슈 번호를 연결 (없으면 생략)) -->

- closed #212 
