### PR TITLE
인증 도메인에 있는 회원탈퇴 삭제 및 회원탈퇴시 삭제 시간이 갱신되도록 수정

### DIFF
--- a/src/main/java/com/example/daobe/auth/application/AuthService.java
+++ b/src/main/java/com/example/daobe/auth/application/AuthService.java
@@ -3,7 +3,6 @@ package com.example.daobe.auth.application;
 import static com.example.daobe.auth.exception.AuthExceptionType.INVALID_TOKEN;
 
 import com.example.daobe.auth.application.dto.TokenResponseDto;
-import com.example.daobe.auth.application.dto.WithdrawRequestDto;
 import com.example.daobe.auth.domain.Token;
 import com.example.daobe.auth.domain.repository.TokenRepository;
 import com.example.daobe.auth.exception.AuthException;
@@ -59,27 +58,5 @@ public class AuthService {
         findToken.isMatchOrElseThrow(userId);
 
         tokenRepository.deleteByTokenId(findToken.getTokenId());
-    }
-
-    /**
-     * <p>user 도메인으로 이동</p>
-     * <p>FE 측에서 엔드포인트 이전 전까지 auth 도메인의 엔드포인트에서 회원탈퇴를 책임집니다.</p>
-     *
-     * @param userId       사용자 식별자
-     * @param currentToken 현재 제공된 refresh token
-     * @param request      회원탈퇴 사유에 대한 정보가 담겨있는 요청
-     * @author Jihongkim98
-     * @deprecated since 09.18.2024
-     */
-    @Deprecated(since = "2024-09-18")
-    public void withdraw(Long userId, String currentToken, WithdrawRequestDto request) {
-        String tokenId = tokenExtractor.extractRefreshToken(currentToken);
-        Token findToken = tokenRepository.findByTokenId(tokenId)
-                .orElseThrow(() -> new AuthException(INVALID_TOKEN));
-        findToken.isMatchOrElseThrow(userId);
-
-        tokenRepository.deleteByTokenId(findToken.getTokenId());
-
-        userService.withdraw(userId, request.toUserWithdrawRequestDto());
     }
 }

--- a/src/main/java/com/example/daobe/auth/presentation/AuthController.java
+++ b/src/main/java/com/example/daobe/auth/presentation/AuthController.java
@@ -4,7 +4,6 @@ import static org.springframework.http.HttpHeaders.SET_COOKIE;
 
 import com.example.daobe.auth.application.AuthService;
 import com.example.daobe.auth.application.dto.TokenResponseDto;
-import com.example.daobe.auth.application.dto.WithdrawRequestDto;
 import com.example.daobe.common.presentation.cookie.CookieHandler;
 import com.example.daobe.common.response.ApiResponse;
 import jakarta.servlet.http.HttpServletResponse;
@@ -14,7 +13,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -54,23 +52,6 @@ public class AuthController {
         response.addHeader(SET_COOKIE, cookie.toString());
         return ResponseEntity.ok(new ApiResponse<>(
                 "LOGOUT_SUCCESS", null
-        ));
-    }
-
-    @Deprecated(since = "2024-09-18")
-    @PostMapping("/withdraw")
-    public ResponseEntity<ApiResponse<Void>> withdraw(
-            @AuthenticationPrincipal Long userId,
-            @RequestBody WithdrawRequestDto request,
-            @CookieValue(COOKIE_REFRESH_TOKEN) String refreshToken,
-            HttpServletResponse response
-    ) {
-        authService.withdraw(userId, refreshToken, request);
-        ResponseCookie cookie = cookieHandler.deleteCookie(COOKIE_REFRESH_TOKEN);
-        response.addHeader(SET_COOKIE, cookie.toString());
-        return ResponseEntity.ok(new ApiResponse<>(
-                "WITHDRAW_SUCCESS",
-                null
         ));
     }
 }

--- a/src/main/java/com/example/daobe/common/domain/BaseTimeEntity.java
+++ b/src/main/java/com/example/daobe/common/domain/BaseTimeEntity.java
@@ -24,4 +24,8 @@ public abstract class BaseTimeEntity {
 
     @Column(name = "deleted_at")
     private LocalDateTime deletedAt;
+
+    protected void updateDeletedTime() {
+        deletedAt = LocalDateTime.now();
+    }
 }

--- a/src/main/java/com/example/daobe/user/domain/User.java
+++ b/src/main/java/com/example/daobe/user/domain/User.java
@@ -79,5 +79,6 @@ public class User extends BaseTimeEntity {
                 .toString();
         this.reasonDetail = detail;
         this.status = UserStatus.DELETED;
+        this.updateDeletedTime();
     }
 }


### PR DESCRIPTION
## 📝 개요

<!-- 이 PR의 목적과 관련된 정보를 간략히 설명합니다. -->

```markdown
인증 도메인에 있는 회원 탈퇴 기능 삭제 및 회원탈퇴시 삭제된 시간이 갱신되도록 수정
```

## ✨ 변경 사항

<!-- 코드나 기능의 주요 변경 사항을 설명 -->

- ✨ 더 이상 사용하지 않는 인증 도메인의 회원탈퇴 기능 삭제 (회원 도메인으로 이전)
- ✨ `BaseTimeEntity` 클래스 내에 `deleted_at` 시간을 갱신할 수 있는 메서드 추가
- ✨ 회원탈퇴시 삭제된 시간이 갱신되도록 수정

## 🔗 관련 이슈

<!-- 이 PR과 관련된 이슈 번호를 연결 (없으면 생략)) -->

- closed #219 
