### PR TITLE
레디스 클라이언트 연결 오류 수정 및 API 요청 제한 예외 추가

### DIFF
--- a/src/main/java/com/example/daobe/common/config/RedisConfig.java
+++ b/src/main/java/com/example/daobe/common/config/RedisConfig.java
@@ -27,15 +27,16 @@ public class RedisConfig {
     private final RedisNotificationMessageListener notificationMessageListener;
 
     @Bean
-    public StatefulRedisConnection<String, byte[]> statefulRedisConnection() {
+    public RedisClient redisClient() {
         RedisURI redisUri = RedisURI.Builder.redis(redisProperties.getHost())
                 .withPort(redisProperties.getPort())
                 .build();
-        try (RedisClient redisClient = RedisClient.create(redisUri)) {
-            return redisClient.connect(RedisCodec.of(StringCodec.UTF8, ByteArrayCodec.INSTANCE));
-        } catch (Exception ex) {
-            throw new RuntimeException("Failed to create Redis connection", ex);
-        }
+        return RedisClient.create(redisUri);
+    }
+
+    @Bean
+    public StatefulRedisConnection<String, byte[]> statefulRedisConnection(RedisClient redisClient) {
+        return redisClient.connect(RedisCodec.of(StringCodec.UTF8, ByteArrayCodec.INSTANCE));
     }
 
     @Bean

--- a/src/main/java/com/example/daobe/common/throttling/RateLimitException.java
+++ b/src/main/java/com/example/daobe/common/throttling/RateLimitException.java
@@ -1,0 +1,10 @@
+package com.example.daobe.common.throttling;
+
+import com.example.daobe.common.exception.BaseException;
+
+public class RateLimitException extends BaseException {
+
+    public RateLimitException(RateLimitExceptionType exceptionType) {
+        super(exceptionType);
+    }
+}

--- a/src/main/java/com/example/daobe/common/throttling/RateLimitExceptionType.java
+++ b/src/main/java/com/example/daobe/common/throttling/RateLimitExceptionType.java
@@ -1,0 +1,27 @@
+package com.example.daobe.common.throttling;
+
+import com.example.daobe.common.exception.BaseExceptionType;
+import org.springframework.http.HttpStatus;
+
+public enum RateLimitExceptionType implements BaseExceptionType {
+    THROTTLING_EXCEPTION("잠시후 다시 시도해주세요.", HttpStatus.TOO_MANY_REQUESTS),
+    ;
+
+    private final String message;
+    private final HttpStatus status;
+
+    RateLimitExceptionType(String message, HttpStatus status) {
+        this.message = message;
+        this.status = status;
+    }
+
+    @Override
+    public String message() {
+        return message;
+    }
+
+    @Override
+    public HttpStatus status() {
+        return status;
+    }
+}

--- a/src/main/java/com/example/daobe/common/throttling/RateLimitInterceptor.java
+++ b/src/main/java/com/example/daobe/common/throttling/RateLimitInterceptor.java
@@ -11,7 +11,6 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.method.HandlerMethod;
@@ -56,8 +55,7 @@ public class RateLimitInterceptor implements HandlerInterceptor {
                 if (!probe.isConsumed()) {
                     long waitForRefillSeconds = TimeUnit.NANOSECONDS.toSeconds(probe.getNanosToWaitForRefill());
                     response.setHeader(RATE_LIMIT_RETRY_AFTER, String.valueOf(waitForRefillSeconds));
-                    response.setStatus(HttpStatus.TOO_MANY_REQUESTS.value());
-                    return false;
+                    throw new RateLimitException(RateLimitExceptionType.THROTTLING_EXCEPTION);
                 }
 
                 long remainingTokens = probe.getRemainingTokens();


### PR DESCRIPTION
## 📝 개요

<!-- 이 PR의 목적과 관련된 정보를 간략히 설명합니다. -->

```markdown
`Connection is closed` 오류 해결 및 API 요청 제한 예외 세분화
```

## ✨ 변경 사항

<!-- 코드나 기능의 주요 변경 사항을 설명 -->

- ✨ `RedisClient`의 생명주기가 Bean 으로 관리되도록 수정
- ✨ API 요청 제한 예외 클래스 및 타입 추가

## 🔗 관련 이슈

<!-- 이 PR과 관련된 이슈 번호를 연결 (없으면 생략)) -->

- closed #227 
- closed #228 
