### PR TITLE
메서드별 호출 및 실행 시간에 대한 로깅 AOP 추가

### DIFF
--- a/src/main/java/com/example/daobe/common/logging/method/MethodLoggingAspect.java
+++ b/src/main/java/com/example/daobe/common/logging/method/MethodLoggingAspect.java
@@ -1,0 +1,77 @@
+package com.example.daobe.common.logging.method;
+
+import java.util.Objects;
+import lombok.RequiredArgsConstructor;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Pointcut;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.RequestContextHolder;
+
+@Aspect
+@Component
+@RequiredArgsConstructor
+public class MethodLoggingAspect {
+
+    private static final String PROXY_CLASS_PREFIX = "Proxy";
+
+    private final MethodLoggingFormatter methodLoggingFormatter;
+
+    @Pointcut("@within(org.springframework.web.bind.annotation.RestController)")
+    public void restController() {
+    }
+
+    @Pointcut("@within(org.springframework.stereotype.Service)")
+    public void service() {
+    }
+
+    @Pointcut("execution(* com.example.daobe..*Repository+.*(..))")
+    public void repository() {
+    }
+
+    @Around("restController() || service() || repository()")
+    public Object logMethodExecution(ProceedingJoinPoint joinPoint) throws Throwable {
+        if (isWithinRequestScope()) {
+            String className = extractClassName(joinPoint);
+            String methodName = joinPoint.getSignature().getName();
+            methodLoggingFormatter.callMethod(className, methodName);
+
+            Object result = proceedResult(joinPoint, className, methodName);
+
+            methodLoggingFormatter.returnMethod(className, methodName);
+            return result;
+        }
+        return joinPoint.proceed();
+    }
+
+    private Object proceedResult(ProceedingJoinPoint joinPoint, String className, String methodName) throws Throwable {
+        try {
+            return joinPoint.proceed();
+        } catch (Throwable ex) {
+            methodLoggingFormatter.throwMethod(className, methodName, ex);
+            throw ex;
+        }
+    }
+
+    private boolean isWithinRequestScope() {
+        return Objects.nonNull(RequestContextHolder.getRequestAttributes());
+    }
+
+    private String extractClassName(ProceedingJoinPoint joinPoint) {
+        Class<?> targetClass = joinPoint.getTarget().getClass();
+        return getClassName(targetClass);
+    }
+
+    private String getClassName(Class<?> clazz) {
+        if (isProxyClassAndHasInterface(clazz)) {
+            return clazz.getInterfaces()[0].getSimpleName();  // 싱글톤 클래스 이름 가져오기
+        }
+        return clazz.getSimpleName();
+    }
+
+    private boolean isProxyClassAndHasInterface(Class<?> clazz) {
+        return clazz.getSimpleName().contains(PROXY_CLASS_PREFIX) &&
+                clazz.getInterfaces().length > 0;
+    }
+}

--- a/src/main/java/com/example/daobe/common/logging/method/MethodLoggingContext.java
+++ b/src/main/java/com/example/daobe/common/logging/method/MethodLoggingContext.java
@@ -1,0 +1,39 @@
+package com.example.daobe.common.logging.method;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.annotation.RequestScope;
+
+@Component
+@RequestScope
+public class MethodLoggingContext {
+
+    private static final String BAR_FORMAT = "|";
+    private static final String DEPTH_BAR_FORMAT = "|    ";
+
+    private int methodDepth;
+    private final long startTime;
+
+    public MethodLoggingContext() {
+        this.methodDepth = 0;
+        this.startTime = System.currentTimeMillis();
+    }
+
+    public void increaseMethodDepth() {
+        this.methodDepth++;
+    }
+
+    public void decreaseMethodDepth() {
+        this.methodDepth--;
+    }
+
+    public String depthLoggingFormatted(String depthPrefixString) {
+        if (methodDepth == 1) {
+            return BAR_FORMAT + depthPrefixString;
+        }
+        return DEPTH_BAR_FORMAT.repeat(methodDepth - 1) + BAR_FORMAT + depthPrefixString;
+    }
+
+    public long getTakenTimeMillis() {
+        return System.currentTimeMillis() - startTime;
+    }
+}

--- a/src/main/java/com/example/daobe/common/logging/method/MethodLoggingFormatter.java
+++ b/src/main/java/com/example/daobe/common/logging/method/MethodLoggingFormatter.java
@@ -1,0 +1,48 @@
+package com.example.daobe.common.logging.method;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class MethodLoggingFormatter {
+
+    private static final String CALL_METHOD = "--->";
+    private static final String RETURN_METHOD = "<---";
+    private static final String THROW_METHOD = "<X--";
+
+    private final MethodLoggingContext context;
+
+    public void callMethod(String className, String methodName) {
+        context.increaseMethodDepth();
+        log.info(
+                "{}",
+                formattedClassAndMethod(context.depthLoggingFormatted(CALL_METHOD), className, methodName)
+        );
+    }
+
+    public void returnMethod(String className, String methodName) {
+        log.info(
+                "{}  |  TAKEN_TIME: {}ms",
+                formattedClassAndMethod(context.depthLoggingFormatted(RETURN_METHOD), className, methodName),
+                context.getTakenTimeMillis()
+        );
+        context.decreaseMethodDepth();
+    }
+
+    public void throwMethod(String className, String methodName, Throwable throwable) {
+        log.info(
+                "{}  |  TAKEN_TIME: {}ms  |  THROWS: {}",
+                formattedClassAndMethod(context.depthLoggingFormatted(THROW_METHOD), className, methodName),
+                context.getTakenTimeMillis(),
+                throwable.getClass().getSimpleName()
+        );
+        context.decreaseMethodDepth();
+    }
+
+    private String formattedClassAndMethod(String prefix, String className, String methodName) {
+        return prefix + className + "." + methodName + "()";
+    }
+}


### PR DESCRIPTION
## 📝 개요

<!-- 이 PR의 목적과 관련된 정보를 간략히 설명합니다. -->

```markdown
성능 테스트시 병목 지점을 찾기 위해, 각 메서드가 호출될 때 실행되는 시간을 측절할 수 있는 AOP 클래스 적용
```

## ✨ 변경 사항

<!-- 코드나 기능의 주요 변경 사항을 설명 -->

- ✨ 메서드 호출 및 반환 시간을 측정하기 위한 AOP 클래스 추가
- ✨ 메서드 호출에 대한 로깅 포멧 추가

## 🔗 관련 이슈

<!-- 이 PR과 관련된 이슈 번호를 연결 (없으면 생략)) -->

- closed #245
