### PR TITLE
채팅, 라운지 도메인 변수명 통일 및 리팩토링

### DIFF
--- a/src/main/java/com/example/daobe/chat/domain/repository/ChatUserRepository.java
+++ b/src/main/java/com/example/daobe/chat/domain/repository/ChatUserRepository.java
@@ -10,5 +10,5 @@ public interface ChatUserRepository extends MongoRepository<ChatUser, String> {
 
     Optional<ChatUser> findByUserId(Long userId);
 
-    List<ChatUser> findAllByUserIdIn(Set<Long> userIds);
+    List<ChatUser> findAllByUserIdIn(Set<Long> userIdSet);
 }

--- a/src/main/java/com/example/daobe/lounge/application/LoungeService.java
+++ b/src/main/java/com/example/daobe/lounge/application/LoungeService.java
@@ -1,11 +1,9 @@
 package com.example.daobe.lounge.application;
 
 import static com.example.daobe.lounge.exception.LoungeExceptionType.INVALID_LOUNGE_ID_EXCEPTION;
-import static com.example.daobe.objet.domain.ObjetStatus.ACTIVE;
 
 import com.example.daobe.lounge.application.dto.LoungeCreateRequestDto;
 import com.example.daobe.lounge.application.dto.LoungeDetailInfoDto;
-import com.example.daobe.lounge.application.dto.LoungeDetailInfoDto.ObjetInfo;
 import com.example.daobe.lounge.application.dto.LoungeInfoDto;
 import com.example.daobe.lounge.domain.Lounge;
 import com.example.daobe.lounge.domain.LoungeStatus;
@@ -48,12 +46,7 @@ public class LoungeService {
 
     public LoungeDetailInfoDto getLoungeDetailInfo(Lounge lounge) {
         lounge.isActiveOrThrow();
-        List<ObjetInfo> objetInfos = lounge.getObjets()
-                .stream()
-                .filter(objet -> objet.getStatus() == ACTIVE)
-                .map(ObjetInfo::of)
-                .toList();
-        return LoungeDetailInfoDto.of(lounge, objetInfos);
+        return LoungeDetailInfoDto.of(lounge);
     }
 
     public Lounge getLoungeById(Long loungeId) {

--- a/src/main/java/com/example/daobe/lounge/application/dto/LoungeDetailInfoDto.java
+++ b/src/main/java/com/example/daobe/lounge/application/dto/LoungeDetailInfoDto.java
@@ -1,39 +1,20 @@
 package com.example.daobe.lounge.application.dto;
 
 import com.example.daobe.lounge.domain.Lounge;
-import com.example.daobe.objet.domain.Objet;
-import java.util.List;
 
 public record LoungeDetailInfoDto(
         Long loungeId,
         String name,
         String type,
-        Long userId,
-        List<ObjetInfo> objets
+        Long userId
 ) {
 
-    public static LoungeDetailInfoDto of(Lounge lounge, List<ObjetInfo> objetInfos) {
+    public static LoungeDetailInfoDto of(Lounge lounge) {
         return new LoungeDetailInfoDto(
                 lounge.getId(),
                 lounge.getName(),
                 lounge.getType().getTypeName(),
-                lounge.getUser().getId(),
-                objetInfos
+                lounge.getUser().getId()
         );
-    }
-
-    public record ObjetInfo(
-            Long objetId,
-            String objetType,
-            String name
-    ) {
-
-        public static ObjetInfo of(Objet objet) {
-            return new ObjetInfo(
-                    objet.getId(),
-                    objet.getType().getType(),
-                    objet.getName()
-            );
-        }
     }
 }

--- a/src/main/java/com/example/daobe/lounge/domain/Lounge.java
+++ b/src/main/java/com/example/daobe/lounge/domain/Lounge.java
@@ -6,7 +6,6 @@ import static com.example.daobe.lounge.exception.LoungeExceptionType.NOT_ALLOW_L
 
 import com.example.daobe.common.domain.BaseTimeEntity;
 import com.example.daobe.lounge.exception.LoungeException;
-import com.example.daobe.objet.domain.Objet;
 import com.example.daobe.user.domain.User;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -18,9 +17,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
-import java.util.List;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -55,12 +52,6 @@ public class Lounge extends BaseTimeEntity {
 
     @Column(columnDefinition = "TEXT", name = "reason_detail")
     private String reasonDetail;
-
-    @OneToMany(mappedBy = "lounge")
-    private List<Objet> objets;
-
-    @OneToMany(mappedBy = "lounge")
-    private List<LoungeSharer> loungeSharers;
 
     @Builder
     public Lounge(User user, String name, LoungeType type, LoungeStatus status) {


### PR DESCRIPTION
## 📝 개요

```markdown
채팅, 라운지 도메인 변수명 통일 및 리팩토링
```

## ✨ 변경 사항

<!-- 코드나 기능의 주요 변경 사항을 설명 -->

- ✨ 채팅, 라운지 도메인에서 컬렉션을 사용하는 변수명 수정
- ✨ 라운지 상세 정보 DTO 에서 Objet 의존성 제거
- ✨ 라운지 엔티티에서 양방향 일대다 관계 필드 의존성 제거 

## 🔗 관련 이슈

- closed #258 

