### PR TITLE
라운지 초대 관련 버그 해결

### DIFF
--- a/src/main/java/com/example/daobe/lounge/domain/repository/LoungeSharerRepository.java
+++ b/src/main/java/com/example/daobe/lounge/domain/repository/LoungeSharerRepository.java
@@ -19,11 +19,23 @@ public interface LoungeSharerRepository extends JpaRepository<LoungeSharer, Long
             """)
     boolean existsActiveLoungeSharerByUserIdAndLoungeId(@Param("userId") Long userId, @Param("loungeId") Long loungeId);
 
+    @Query("""
+            SELECT CASE WHEN EXISTS (
+                SELECT 1
+                FROM LoungeSharer ls
+                WHERE ls.user.id = :userId
+                AND ls.lounge.id = :loungeId
+            ) THEN true ELSE false END
+            """)
+    boolean existsLoungeSharerByUserIdAndLoungeId(@Param("userId") Long userId, @Param("loungeId") Long loungeId);
+
     List<LoungeSharer> findByLounge_IdAndUser_NicknameContaining(Long loungeId, String nickname);
 
     @Query("""
                 SELECT COUNT(ls) FROM LoungeSharer ls
-                JOIN ls.lounge l WHERE l.status = 'ACTIVE'
+                JOIN ls.lounge l
+                WHERE l.status = 'ACTIVE'
+                AND ls.status = 'ACTIVE'
                 AND ls.user.id = :userId
             """)
     long countActiveLoungeSharerByUserId(@Param("userId") Long userId);

--- a/src/main/java/com/example/daobe/lounge/exception/LoungeExceptionType.java
+++ b/src/main/java/com/example/daobe/lounge/exception/LoungeExceptionType.java
@@ -9,7 +9,8 @@ public enum LoungeExceptionType implements BaseExceptionType {
     NOT_ACTIVE_LOUNGE_EXCEPTION("활성 상태가 아닌 라운지입니다.", HttpStatus.NOT_FOUND),
     INVALID_LOUNGE_OWNER_EXCEPTION("유효하지 않은 라운지 주인입니다.", HttpStatus.FORBIDDEN),
     INVALID_LOUNGE_SHARER_EXCEPTION("유효하지 않은 라운지 공유자입니다.", HttpStatus.FORBIDDEN),
-    ALREADY_INVITED_USER_EXCEPTION("이미 라운지에 소속된 유저입니다.", HttpStatus.BAD_REQUEST),
+    ALREADY_EXISTS_LOUNGE_USER_EXCEPTION("이미 라운지에 소속된 유저입니다.", HttpStatus.CONFLICT),
+    ALREADY_INVITED_USER_EXCEPTION("이미 라운지에 초대된 유저입니다.", HttpStatus.BAD_REQUEST),
     ALREADY_DELETED_LOUNGE_EXCEPTION("이미 삭제된 라운지입니다.", HttpStatus.NOT_FOUND),
     MAXIMUM_LOUNGE_LIMIT_EXCEEDED_EXCEPTION("라운지 개수는 최대 4개를 초과할 수 없습니다.", HttpStatus.BAD_REQUEST),
     NOT_ALLOW_LOUNGE_WITHDRAW_EXCEPTION("라운지 생성자는 탈퇴할 수 없습니다.", HttpStatus.BAD_REQUEST);


### PR DESCRIPTION
## 📝 개요

```markdown
라운지 초대 관련 버그 해결
```

## ✨ 변경 사항

<!-- 코드나 기능의 주요 변경 사항을 설명 -->

- ✨ 이미 초대된 유저 초대시 데이터베이스에 초대 상태가 중복 저장되는 버그 해결
- ✨ 라운지 초대 수락 전 PENDING 상태임에도 라운지 개수에 포함되는 버그 해결

## 🔗 관련 이슈

- closed #261 
