### PR TITLE
최대 개수의 라운지에 소속되어도 초대 수락되는 버그 해결

### DIFF
--- a/src/main/java/com/example/daobe/lounge/application/LoungeFacadeService.java
+++ b/src/main/java/com/example/daobe/lounge/application/LoungeFacadeService.java
@@ -66,7 +66,7 @@ public class LoungeFacadeService {
     public void updateInvitedUserStatus(Long userId, Long loungeId) {
         User invitedUser = userService.getUserById(userId);
         Lounge findLounge = loungeService.getLoungeById(loungeId);
-        loungeSharerService.updateInvitedUserStatus(invitedUser, findLounge);
+        loungeSharerService.updateInvitedUserStatus(invitedUser.getId(), findLounge.getId());
     }
 
     // 라운지 내 유저 검색

--- a/src/main/java/com/example/daobe/lounge/application/LoungeSharerService.java
+++ b/src/main/java/com/example/daobe/lounge/application/LoungeSharerService.java
@@ -30,7 +30,6 @@ public class LoungeSharerService {
     private final LoungeSharerRepository loungeSharerRepository;
 
     public void createAndSaveLoungeSharer(User user, Lounge lounge) {
-        // 라운지 최대 개수를 초과하는지 검증
         if (isOverMaximumCountLounge(user.getId())) {
             throw new LoungeException(MAXIMUM_LOUNGE_LIMIT_EXCEEDED_EXCEPTION);
         }
@@ -54,12 +53,18 @@ public class LoungeSharerService {
     }
 
     // FIXME:
-    public void updateInvitedUserStatus(User invitedUser, Lounge lounge) {
-        LoungeSharer findSharer = loungeSharerRepository.findByUserIdAndLoungeId(invitedUser.getId(), lounge.getId());
-        if (!findSharer.isActive()) {
-            findSharer.updateStatusActive();
-            loungeSharerRepository.save(findSharer);
+    public void updateInvitedUserStatus(Long invitedUserId, Long loungeId) {
+        LoungeSharer loungeSharer = loungeSharerRepository.findByUserIdAndLoungeId(invitedUserId, loungeId)
+                .orElseThrow(() -> new LoungeException(INVALID_LOUNGE_SHARER_EXCEPTION));
+        if (loungeSharer.isActive()) {
+            throw new LoungeException(ALREADY_EXISTS_LOUNGE_USER_EXCEPTION);
         }
+
+        if (isOverMaximumCountLounge(invitedUserId)) {
+            throw new LoungeException(MAXIMUM_LOUNGE_LIMIT_EXCEEDED_EXCEPTION);
+        }
+        loungeSharer.updateStatusActive();
+        loungeSharerRepository.save(loungeSharer);
     }
 
     public List<LoungeSharerInfoResponseDto> searchLoungeSharer(Long userId, String nickname, Lounge lounge) {

--- a/src/main/java/com/example/daobe/lounge/domain/repository/LoungeSharerRepository.java
+++ b/src/main/java/com/example/daobe/lounge/domain/repository/LoungeSharerRepository.java
@@ -2,6 +2,7 @@ package com.example.daobe.lounge.domain.repository;
 
 import com.example.daobe.lounge.domain.LoungeSharer;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -42,5 +43,5 @@ public interface LoungeSharerRepository extends JpaRepository<LoungeSharer, Long
 
     void deleteByUserIdAndLoungeId(Long userId, Long loungeId);
 
-    LoungeSharer findByUserIdAndLoungeId(Long userId, Long loungeId);
+    Optional<LoungeSharer> findByUserIdAndLoungeId(Long userId, Long loungeId);
 }


### PR DESCRIPTION
## 📝 개요

```markdown
최대 개수의 라운지에 소속되어도 초대 수락되는 버그 해결
```

## ✨ 변경 사항

- ✨ 라운지 및 유저 아이디로 라운지 조회시 Optional 로 반환하도록 수정
- ✨ 라운지 수락시 최대 라운지 개수인지 검증하는 로직 추가

## 🔗 관련 이슈

- closed #261