### PR TITLE
오브제 공유자 활성 상태 추가

### DIFF
--- a/src/main/java/com/example/daobe/objet/application/ObjetEventListener.java
+++ b/src/main/java/com/example/daobe/objet/application/ObjetEventListener.java
@@ -1,8 +1,11 @@
 package com.example.daobe.objet.application;
 
 import com.example.daobe.lounge.domain.event.LoungeDeleteEvent;
+import com.example.daobe.lounge.domain.event.LoungeWithdrawEvent;
 import com.example.daobe.objet.domain.Objet;
+import com.example.daobe.objet.domain.ObjetSharer;
 import com.example.daobe.objet.domain.repository.ObjetRepository;
+import com.example.daobe.objet.domain.repository.ObjetSharerRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -19,13 +22,26 @@ import org.springframework.transaction.event.TransactionalEventListener;
 public class ObjetEventListener {
 
     private final ObjetRepository objetRepository;
+    private final ObjetSharerRepository objetSharerRepository;
 
     @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void loungeDeletedListener(LoungeDeleteEvent event) {
         List<Objet> objetList = objetRepository.findActiveObjetListInLounge(event.loungeId());
-        objetList.forEach(Objet::updateDeleteStatus);
+        objetList.forEach(Objet::updateStatusDeleted);
         objetRepository.saveAll(objetList);
+    }
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void loungeWithdrawListener(LoungeWithdrawEvent event) {
+        List<ObjetSharer> objetSharerList = objetSharerRepository.findByUserIdAndLoungeId(
+                event.userId(),
+                event.loungeId()
+        );
+        objetSharerList.forEach(ObjetSharer::updateStatusDeleted);
+        objetSharerRepository.saveAll(objetSharerList);
     }
 }

--- a/src/main/java/com/example/daobe/objet/application/ObjetSharerService.java
+++ b/src/main/java/com/example/daobe/objet/application/ObjetSharerService.java
@@ -72,7 +72,7 @@ public class ObjetSharerService {
 
     @Transactional
     public ObjetSharerResponseDto getObjetSharerList(Long objetId) {
-        List<ObjetSharer> objetSharerList = objetSharerRepository.findAllByObjetId(objetId);
+        List<ObjetSharer> objetSharerList = objetSharerRepository.findAllByObjetIdAndActiveStatus(objetId);
         return ObjetSharerResponseDto.of(objetSharerList);
     }
 

--- a/src/main/java/com/example/daobe/objet/domain/Objet.java
+++ b/src/main/java/com/example/daobe/objet/domain/Objet.java
@@ -95,7 +95,7 @@ public class Objet extends BaseTimeEntity {
         this.status = ObjetStatus.DELETED;
     }
 
-    public void updateDeleteStatus() {
+    public void updateStatusDeleted() {
         this.status = ObjetStatus.DELETED;
     }
 

--- a/src/main/java/com/example/daobe/objet/domain/ObjetSharer.java
+++ b/src/main/java/com/example/daobe/objet/domain/ObjetSharer.java
@@ -1,8 +1,13 @@
 package com.example.daobe.objet.domain;
 
+import static com.example.daobe.objet.domain.ObjetSharerStatus.ACTIVE;
+import static com.example.daobe.objet.domain.ObjetSharerStatus.DELETED;
+
 import com.example.daobe.user.domain.User;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -34,9 +39,25 @@ public class ObjetSharer {
     @ManyToOne(fetch = FetchType.LAZY)
     private Objet objet;
 
+    @Enumerated(EnumType.STRING)
+    private ObjetSharerStatus status;
+
     @Builder
     public ObjetSharer(User user, Objet objet) {
         this.user = user;
         this.objet = objet;
+        this.status = ACTIVE;
+    }
+
+    public boolean isActive() {
+        return status.isActive();
+    }
+
+    public void updateStatusActive() {
+        this.status = ACTIVE;
+    }
+
+    public void updateStatusDeleted() {
+        this.status = DELETED;
     }
 }

--- a/src/main/java/com/example/daobe/objet/domain/ObjetSharerStatus.java
+++ b/src/main/java/com/example/daobe/objet/domain/ObjetSharerStatus.java
@@ -1,0 +1,11 @@
+package com.example.daobe.objet.domain;
+
+public enum ObjetSharerStatus {
+    DELETED,
+    ACTIVE,
+    ;
+
+    public boolean isActive() {
+        return this == ACTIVE;
+    }
+}

--- a/src/main/java/com/example/daobe/objet/domain/repository/ObjetSharerRepository.java
+++ b/src/main/java/com/example/daobe/objet/domain/repository/ObjetSharerRepository.java
@@ -12,17 +12,25 @@ public interface ObjetSharerRepository extends JpaRepository<ObjetSharer, Long> 
     @Query("""
             SELECT os FROM ObjetSharer os JOIN FETCH Objet o
             ON os.objet.id = o.id
-            WHERE o.status = 'ACTIVE' AND os.user.id = :userId
+            WHERE o.status = 'ACTIVE' AND os.status='ACTIVE' AND os.user.id = :userId
             ORDER BY o.createdAt DESC
             LIMIT 4
             """)
     List<ObjetSharer> findTop4ByUserIdAndActiveStatus(Long userId);
 
-    List<ObjetSharer> findAllByObjetId(Long objetId);
+    @Query("SELECT os FROM ObjetSharer os WHERE os.id=:objetId AND os.status = 'ACTIVE'")
+    List<ObjetSharer> findAllByObjetIdAndActiveStatus(Long objetId);
 
-    @Query("SELECT os.user.id FROM ObjetSharer os WHERE os.objet = :objet")
+    @Query("SELECT os.user.id FROM ObjetSharer os WHERE os.objet = :objet AND os.status = 'ACTIVE'")
     List<Long> findSharerIdListByObjet(@Param("objet") Objet objet);
 
     void deleteAllByObjetAndUserIdIn(Objet objet, List<Long> userIds);
+
+    @Query("""
+            SELECT os FROM ObjetSharer os JOIN FETCH Objet o
+            ON os.objet.id = o.id
+            WHERE os.user.id = :userId AND o.lounge.id = :loungeId AND os.status = 'ACTIVE'
+            """)
+    List<ObjetSharer> findByUserIdAndLoungeId(Long userId, Long loungeId);
 
 }

--- a/src/main/java/com/example/daobe/objet/infrastructure/querydsl/QueryDslCustomObjetRepository.java
+++ b/src/main/java/com/example/daobe/objet/infrastructure/querydsl/QueryDslCustomObjetRepository.java
@@ -4,6 +4,7 @@ import static com.example.daobe.objet.domain.QObjet.objet;
 import static com.example.daobe.objet.domain.QObjetSharer.objetSharer;
 
 import com.example.daobe.objet.domain.Objet;
+import com.example.daobe.objet.domain.ObjetSharerStatus;
 import com.example.daobe.objet.domain.ObjetStatus;
 import com.example.daobe.objet.domain.repository.CustomObjetRepository;
 import com.example.daobe.objet.domain.repository.dto.ObjetFindCondition;
@@ -35,7 +36,10 @@ public class QueryDslCustomObjetRepository implements CustomObjetRepository {
 
         List<Objet> result = (condition.userId() != null)
                 ? query.join(objetSharer).on(objetSharer.objet.eq(objet))
-                .where(objetSharer.user.id.eq(condition.userId())).fetch()
+                .where(
+                        objetSharer.user.id.eq(condition.userId()),
+                        objetSharer.status.eq(ObjetSharerStatus.ACTIVE)
+                ).fetch()
                 : query.fetch();
 
         boolean hasNext = false;

--- a/src/main/resources/db/migration/V4__add_status_in_objets_sharer_status.sql
+++ b/src/main/resources/db/migration/V4__add_status_in_objets_sharer_status.sql
@@ -1,0 +1,2 @@
+ALTER TABLE objets_sharers
+    ADD COLUMN status varchar(255);


### PR DESCRIPTION
## 📝 개요

<!-- 이 PR의 목적과 관련된 정보를 간략히 설명합니다. -->

```markdown
라운지 탈퇴시 해당 공유자를 비활성화 처리하기 위해 오브제 공유자 활성 상태를 추가
```

## ✨ 변경 사항

<!-- 코드나 기능의 주요 변경 사항을 설명 -->

- ✨ 오브제 공유자 상태 추가 마이그레이션 파일 추가
- ✨ 라운지 탈퇴 이벤트 구독 로직 추가
- ✨ 오브제 공유자 상태 기반 로직 적용

## 🔗 관련 이슈

<!-- 이 PR과 관련된 이슈 번호를 연결 (없으면 생략)) -->

- closed #265