### PR TITLE
라운지 이벤트 리팩토링

### DIFF
--- a/src/main/java/com/example/daobe/lounge/application/LoungeService.java
+++ b/src/main/java/com/example/daobe/lounge/application/LoungeService.java
@@ -10,7 +10,7 @@ import com.example.daobe.lounge.application.dto.LoungeInfoDto;
 import com.example.daobe.lounge.domain.Lounge;
 import com.example.daobe.lounge.domain.LoungeStatus;
 import com.example.daobe.lounge.domain.LoungeType;
-import com.example.daobe.lounge.domain.event.LoungeDeleteEvent;
+import com.example.daobe.lounge.domain.event.LoungeDeletedEvent;
 import com.example.daobe.lounge.domain.repository.LoungeRepository;
 import com.example.daobe.lounge.exception.LoungeException;
 import com.example.daobe.user.domain.User;
@@ -63,6 +63,6 @@ public class LoungeService {
 
     public void deleteLoungeByUserId(User user, Lounge lounge) {
         lounge.softDelete(user.getId());
-        eventPublisher.publishEvent(new LoungeDeleteEvent(lounge.getId()));
+        eventPublisher.publishEvent(new LoungeDeletedEvent(lounge.getId()));
     }
 }

--- a/src/main/java/com/example/daobe/lounge/application/LoungeSharerService.java
+++ b/src/main/java/com/example/daobe/lounge/application/LoungeSharerService.java
@@ -50,7 +50,7 @@ public class LoungeSharerService {
                 .lounge(lounge)
                 .build();
         loungeSharerRepository.save(loungeSharer);
-        eventPublisher.publishEvent(new LoungeInvitedEvent(inviterId, loungeSharer));
+        eventPublisher.publishEvent(new LoungeInvitedEvent(lounge.getId(), inviterId, loungeSharer));
     }
 
     // FIXME:

--- a/src/main/java/com/example/daobe/lounge/application/LoungeSharerService.java
+++ b/src/main/java/com/example/daobe/lounge/application/LoungeSharerService.java
@@ -9,7 +9,7 @@ import com.example.daobe.lounge.application.dto.LoungeSharerInfoResponseDto;
 import com.example.daobe.lounge.domain.Lounge;
 import com.example.daobe.lounge.domain.LoungeSharer;
 import com.example.daobe.lounge.domain.LoungeSharerStatus;
-import com.example.daobe.lounge.domain.event.LoungeInviteEvent;
+import com.example.daobe.lounge.domain.event.LoungeInvitedEvent;
 import com.example.daobe.lounge.domain.event.LoungeWithdrawEvent;
 import com.example.daobe.lounge.domain.repository.LoungeSharerRepository;
 import com.example.daobe.lounge.exception.LoungeException;
@@ -50,7 +50,7 @@ public class LoungeSharerService {
                 .lounge(lounge)
                 .build();
         loungeSharerRepository.save(loungeSharer);
-        eventPublisher.publishEvent(new LoungeInviteEvent(inviterId, loungeSharer));
+        eventPublisher.publishEvent(new LoungeInvitedEvent(inviterId, loungeSharer));
     }
 
     // FIXME:

--- a/src/main/java/com/example/daobe/lounge/domain/event/LoungeDeletedEvent.java
+++ b/src/main/java/com/example/daobe/lounge/domain/event/LoungeDeletedEvent.java
@@ -1,6 +1,6 @@
 package com.example.daobe.lounge.domain.event;
 
-public record LoungeDeleteEvent(
+public record LoungeDeletedEvent(
         Long loungeId
 ) {
 }

--- a/src/main/java/com/example/daobe/lounge/domain/event/LoungeInvitedEvent.java
+++ b/src/main/java/com/example/daobe/lounge/domain/event/LoungeInvitedEvent.java
@@ -1,17 +1,18 @@
 package com.example.daobe.lounge.domain.event;
 
+import static com.example.daobe.lounge.exception.LoungeExceptionType.LOUNGE_NOT_CREATED_EXCEPTION_MESSAGE;
+
 import com.example.daobe.common.domain.DomainEvent;
 import com.example.daobe.lounge.domain.LoungeSharer;
+import com.example.daobe.lounge.exception.LoungeException;
 
-public class LoungeInviteEvent implements DomainEvent {
-
-    private static final String LOUNGE_NOT_CREATED_EXCEPTION_MESSAGE = "아직 생성되지 않은 라운지";
+public class LoungeInvitedEvent implements DomainEvent {
 
     private final Long domainId;
     private final Long sendUserId;
     private final Long receiveUserId;
 
-    public LoungeInviteEvent(Long sendUserId, LoungeSharer loungeSharer) {
+    public LoungeInvitedEvent(Long sendUserId, LoungeSharer loungeSharer) {
         validate(loungeSharer);
         this.domainId = loungeSharer.getLounge().getId();
         this.sendUserId = sendUserId;
@@ -20,7 +21,7 @@ public class LoungeInviteEvent implements DomainEvent {
 
     private void validate(LoungeSharer loungeSharer) {
         if (loungeSharer.getId() == null) {
-            throw new RuntimeException(LOUNGE_NOT_CREATED_EXCEPTION_MESSAGE);
+            throw new LoungeException(LOUNGE_NOT_CREATED_EXCEPTION_MESSAGE);
         }
     }
 
@@ -37,5 +38,9 @@ public class LoungeInviteEvent implements DomainEvent {
     @Override
     public Long getReceiveUserId() {
         return receiveUserId;
+    }
+
+    public Long getLoungeId() {
+        return loungeId;
     }
 }

--- a/src/main/java/com/example/daobe/lounge/domain/event/LoungeInvitedEvent.java
+++ b/src/main/java/com/example/daobe/lounge/domain/event/LoungeInvitedEvent.java
@@ -9,12 +9,14 @@ import com.example.daobe.lounge.exception.LoungeException;
 public class LoungeInvitedEvent implements DomainEvent {
 
     private final Long domainId;
+    private final Long loungeId;
     private final Long sendUserId;
     private final Long receiveUserId;
 
-    public LoungeInvitedEvent(Long sendUserId, LoungeSharer loungeSharer) {
+    public LoungeInvitedEvent(Long loungeId, Long sendUserId, LoungeSharer loungeSharer) {
         validate(loungeSharer);
         this.domainId = loungeSharer.getLounge().getId();
+        this.loungeId = loungeId;
         this.sendUserId = sendUserId;
         this.receiveUserId = loungeSharer.getUser().getId();
     }

--- a/src/main/java/com/example/daobe/lounge/exception/LoungeExceptionType.java
+++ b/src/main/java/com/example/daobe/lounge/exception/LoungeExceptionType.java
@@ -13,7 +13,9 @@ public enum LoungeExceptionType implements BaseExceptionType {
     ALREADY_INVITED_LOUNGE_USER_EXCEPTION("이미 라운지에 초대된 유저입니다.", HttpStatus.CONFLICT),
     ALREADY_DELETED_LOUNGE_EXCEPTION("이미 삭제된 라운지입니다.", HttpStatus.NOT_FOUND),
     MAXIMUM_LOUNGE_LIMIT_EXCEEDED_EXCEPTION("라운지 개수는 최대 4개를 초과할 수 없습니다.", HttpStatus.BAD_REQUEST),
-    NOT_ALLOW_LOUNGE_WITHDRAW_EXCEPTION("라운지 생성자는 탈퇴할 수 없습니다.", HttpStatus.BAD_REQUEST);
+    NOT_ALLOW_LOUNGE_WITHDRAW_EXCEPTION("라운지 생성자는 탈퇴할 수 없습니다.", HttpStatus.BAD_REQUEST),
+    LOUNGE_NOT_CREATED_EXCEPTION_MESSAGE("아직 생성되지 않은 라운지입니다.", HttpStatus.NOT_FOUND),
+    ;
 
     private final String message;
     private final HttpStatus status;

--- a/src/main/java/com/example/daobe/notification/domain/NotificationEventType.java
+++ b/src/main/java/com/example/daobe/notification/domain/NotificationEventType.java
@@ -3,14 +3,14 @@ package com.example.daobe.notification.domain;
 import static com.example.daobe.notification.exception.NotificationExceptionType.NON_MATCH_DOMAIN_EVENT_TYPE;
 
 import com.example.daobe.common.domain.DomainEvent;
-import com.example.daobe.lounge.domain.event.LoungeInviteEvent;
+import com.example.daobe.lounge.domain.event.LoungeInvitedEvent;
 import com.example.daobe.notification.exception.NotificationException;
 import com.example.daobe.objet.domain.event.ObjetInviteEvent;
 import com.example.daobe.user.domain.event.UserPokeEvent;
 import java.util.stream.Stream;
 
 public enum NotificationEventType {
-    LOUNGE_INVITE_EVENT("N0001", LoungeInviteEvent.class),
+    LOUNGE_INVITE_EVENT("N0001", LoungeInvitedEvent.class),
     OBJET_INVITE_EVENT("N0002", ObjetInviteEvent.class),
     USER_POKE_EVENT("N0003", UserPokeEvent.class),
     ;

--- a/src/main/java/com/example/daobe/notification/domain/convert/LoungeInviteEventConvert.java
+++ b/src/main/java/com/example/daobe/notification/domain/convert/LoungeInviteEventConvert.java
@@ -3,7 +3,7 @@ package com.example.daobe.notification.domain.convert;
 import static com.example.daobe.lounge.exception.LoungeExceptionType.INVALID_LOUNGE_ID_EXCEPTION;
 
 import com.example.daobe.lounge.domain.Lounge;
-import com.example.daobe.lounge.domain.event.LoungeInviteEvent;
+import com.example.daobe.lounge.domain.event.LoungeInvitedEvent;
 import com.example.daobe.lounge.domain.repository.LoungeRepository;
 import com.example.daobe.lounge.exception.LoungeException;
 import com.example.daobe.notification.domain.convert.dto.DomainInfo;
@@ -20,7 +20,7 @@ public class LoungeInviteEventConvert implements DomainEventConvert {
 
     @Override
     public String supportNameToLowerCase() {
-        return LoungeInviteEvent.class.getName().toLowerCase();
+        return LoungeInvitedEvent.class.getName().toLowerCase();
     }
 
     @Override

--- a/src/main/java/com/example/daobe/objet/application/ObjetEventListener.java
+++ b/src/main/java/com/example/daobe/objet/application/ObjetEventListener.java
@@ -1,6 +1,6 @@
 package com.example.daobe.objet.application;
 
-import com.example.daobe.lounge.domain.event.LoungeDeleteEvent;
+import com.example.daobe.lounge.domain.event.LoungeDeletedEvent;
 import com.example.daobe.objet.domain.Objet;
 import com.example.daobe.objet.domain.repository.ObjetRepository;
 import java.util.List;
@@ -23,7 +23,7 @@ public class ObjetEventListener {
     @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     @Transactional(propagation = Propagation.REQUIRES_NEW)
-    public void loungeDeletedListener(LoungeDeleteEvent event) {
+    public void loungeDeletedListener(LoungeDeletedEvent event) {
         List<Objet> objetList = objetRepository.findActiveObjetListInLounge(event.loungeId());
         objetList.forEach(Objet::updateDeleteStatus);
         objetRepository.saveAll(objetList);


### PR DESCRIPTION
## 📝 개요

```markdown
라운지 이벤트 리팩토링
```

## ✨ 변경 사항

- ✨ 라운지 이벤트 클래스명 과거형으로 수정
- ✨ 라운지 초대 이벤트에 라운지 아이디 추가
- ✨ 생성되지 않은 라운지에 대한 커스텀 예외 추가

## 🔗 관련 이슈

- closed #256
