### PR TITLE
스프링 엑츄에이터 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,7 @@ repositories {
 dependencies {
     // Spring
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
@@ -73,6 +74,9 @@ dependencies {
 
     // RateLimit
     implementation 'com.bucket4j:bucket4j_jdk17-lettuce:8.14.0'
+
+    // Prometheus
+    implementation 'io.micrometer:micrometer-registry-prometheus'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/daobe/auth/infrastructure/security/BasicAuthenticationProvider.java
+++ b/src/main/java/com/example/daobe/auth/infrastructure/security/BasicAuthenticationProvider.java
@@ -1,0 +1,59 @@
+package com.example.daobe.auth.infrastructure.security;
+
+import static com.example.daobe.auth.infrastructure.security.exception.SecurityExceptionType.INVALID_USER_INFO;
+
+import com.example.daobe.auth.infrastructure.security.exception.SecurityException;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.security.SecurityProperties;
+import org.springframework.boot.autoconfigure.security.SecurityProperties.User;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class BasicAuthenticationProvider implements AuthenticationProvider {
+
+    private static final String ROLE_PREFIX = "ROLE_";
+
+    private final SecurityProperties properties;
+
+    @Override
+    public Authentication authenticate(
+            Authentication authentication
+    ) throws AuthenticationException {
+        String name = authentication.getName();
+        String password = authentication.getCredentials().toString();
+        List<SimpleGrantedAuthority> authorityList = extractAuthorityList(name, password);
+        return new UsernamePasswordAuthenticationToken(name, password, authorityList);
+    }
+
+    @Override
+    public boolean supports(Class<?> authentication) {
+        return UsernamePasswordAuthenticationToken.class
+                .isAssignableFrom(authentication);
+    }
+
+    private List<SimpleGrantedAuthority> extractAuthorityList(
+            String name,
+            String password
+    ) throws AuthenticationException {
+        User securityUser = properties.getUser();
+        if (isMatchUser(name, password, securityUser)) {
+            throw new SecurityException(INVALID_USER_INFO);
+        }
+        return securityUser.getRoles().stream()
+                .map(value -> new SimpleGrantedAuthority(ROLE_PREFIX + value))
+                .collect(Collectors.toList());
+    }
+
+    private boolean isMatchUser(String name, String password, User securityUser) {
+        return !name.equals(securityUser.getName()) ||
+                !password.equals(securityUser.getPassword());
+    }
+}

--- a/src/main/java/com/example/daobe/auth/infrastructure/security/exception/SecurityExceptionType.java
+++ b/src/main/java/com/example/daobe/auth/infrastructure/security/exception/SecurityExceptionType.java
@@ -4,6 +4,7 @@ public enum SecurityExceptionType {
     UNAUTHORIZED("인증 정보가 제공되지 않았습니다."),
     INVALID_TOKEN("유효하지 않는 토큰입니다."),
     EXPIRED_TOKEN("이미 만료된 토큰입니다."),
+    INVALID_USER_INFO("유효하지 않는 사용자 이름 혹은 비밀번호 입니다."),
     ;
 
     private final String message;

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,7 +1,4 @@
 management:
-  server:
-    port: 9876
-
   endpoints:
     web:
       exposure:
@@ -59,6 +56,10 @@ spring:
     open-in-view: false
 
   security:
+    user:
+      name: admin
+      password: admin
+      roles: ADMIN
     oauth2:
       success-redirect: http://localhost:5173
       client:

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,3 +1,12 @@
+management:
+  server:
+    port: 9876
+
+  endpoints:
+    web:
+      exposure:
+        include: "prometheus,health"
+
 spring:
   jackson:
     property-naming-strategy: SNAKE_CASE


### PR DESCRIPTION
## 📝 개요

<!-- 이 PR의 목적과 관련된 정보를 간략히 설명합니다. -->

```markdown
서버 애플리케이션 상태를 모니터링하기 위해서 스프링 엑츄에이터 설정 추가 및 엑츄에이터 보안을 위해 Basic 인증 추가
```

## ✨ 변경 사항

<!-- 코드나 기능의 주요 변경 사항을 설명 -->

- ✨ 엑츄에이터 접근 제한을 위한 Basic 인증 추가
- ✨ 엑츄에이터 및 프로메테우스 의존성 추가
- ✨ 엑츄에이터 및 시큐리티 프로퍼티 설정 수정
- ✨개발 및 운영 서버 프로퍼티 설정 추가

## 🔗 관련 이슈

<!-- 이 PR과 관련된 이슈 번호를 연결 (없으면 생략)) -->

- closed #266 
- closed #269 

## ℹ️ 참고 사항

<!-- 리뷰어가 알 필요가 있는 추가 정보나 문서, 참고 링크를 포함 -->

기존에 `JWT` 인증을 통해 엑츄에이터에 대한 접근을 막는 것을 고려했었는데, `access_token` 이 만료될 수 있다는 치명적인 단점이 있고, 서버끼리 private 네트워크를 통해서 통신할 예정이므로 엑츄에이터 접근에 한정하여 `Basic` 인증을 추가로 구현하기로 결정했습니다.
