### PR TITLE
라운지 초대 이벤트에서 존재하지 않는 필드를 호출 하던 문제 수정

### DIFF
--- a/src/main/java/com/example/daobe/lounge/domain/event/LoungeInvitedEvent.java
+++ b/src/main/java/com/example/daobe/lounge/domain/event/LoungeInvitedEvent.java
@@ -39,8 +39,4 @@ public class LoungeInvitedEvent implements DomainEvent {
     public Long getReceiveUserId() {
         return receiveUserId;
     }
-
-    public Long getLoungeId() {
-        return loungeId;
-    }
 }

--- a/src/main/java/com/example/daobe/lounge/exception/LoungeExceptionType.java
+++ b/src/main/java/com/example/daobe/lounge/exception/LoungeExceptionType.java
@@ -14,7 +14,7 @@ public enum LoungeExceptionType implements BaseExceptionType {
     ALREADY_DELETED_LOUNGE_EXCEPTION("이미 삭제된 라운지입니다.", HttpStatus.NOT_FOUND),
     MAXIMUM_LOUNGE_LIMIT_EXCEEDED_EXCEPTION("라운지 개수는 최대 4개를 초과할 수 없습니다.", HttpStatus.BAD_REQUEST),
     NOT_ALLOW_LOUNGE_WITHDRAW_EXCEPTION("라운지 생성자는 탈퇴할 수 없습니다.", HttpStatus.BAD_REQUEST),
-    LOUNGE_NOT_CREATED_EXCEPTION_MESSAGE("아직 생성되지 않은 라운지입니다.", HttpStatus.NOT_FOUND),
+    LOUNGE_NOT_CREATED_EXCEPTION_MESSAGE("아직 생성되지 않은 라운지입니다.", HttpStatus.INTERNAL_SERVER_ERROR),
     ;
 
     private final String message;


### PR DESCRIPTION
## 📝 개요

<!-- 이 PR의 목적과 관련된 정보를 간략히 설명합니다. -->

```markdown
라운지 초대 이벤트 객체에서 존재하지 않는 필드를 호출하는 메서드 삭제 및 라운지가 생성되기 전에 이벤트가 발행될 경우 500 오류가 발생하도록 수정
```

## ✨ 변경 사항

<!-- 코드나 기능의 주요 변경 사항을 설명 -->

- ✨ `LoungeInviteEvent` 에서 `getLoungeId()` 메서드 삭제
- ✨ 라운지가 생성되기 전 이벤트가 발행되는 경우에 대한 예외 응답을 500으로 변경

## 🔗 관련 이슈

<!-- 이 PR과 관련된 이슈 번호를 연결 (없으면 생략)) -->

- closed #276 
