### PR TITLE
라운지 재초대 유저 활성화하는 기능 추가

### DIFF
--- a/src/main/java/com/example/daobe/objet/domain/repository/ObjetSharerRepository.java
+++ b/src/main/java/com/example/daobe/objet/domain/repository/ObjetSharerRepository.java
@@ -2,6 +2,7 @@ package com.example.daobe.objet.domain.repository;
 
 import com.example.daobe.objet.domain.Objet;
 import com.example.daobe.objet.domain.ObjetSharer;
+import com.example.daobe.objet.domain.ObjetSharerStatus;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -29,8 +30,8 @@ public interface ObjetSharerRepository extends JpaRepository<ObjetSharer, Long> 
     @Query("""
             SELECT os FROM ObjetSharer os JOIN FETCH Objet o
             ON os.objet.id = o.id
-            WHERE os.user.id = :userId AND o.lounge.id = :loungeId AND os.status = 'ACTIVE'
+            WHERE os.user.id = :userId AND o.lounge.id = :loungeId AND os.status = :objetSharerStatus
             """)
-    List<ObjetSharer> findByUserIdAndLoungeId(Long userId, Long loungeId);
+    List<ObjetSharer> findByUserIdAndLoungeId(Long userId, Long loungeId, ObjetSharerStatus objetSharerStatus);
 
 }


### PR DESCRIPTION
## 📝 개요

<!-- 이 PR의 목적과 관련된 정보를 간략히 설명합니다. -->

```markdown
라운지 재초대시 해당 멤버의 오브제 공유자 상태 복구
```

## ✨ 변경 사항

<!-- 코드나 기능의 주요 변경 사항을 설명 -->

- ♻️ 라운지에 속하는 오브제 공유자 목록 조회 쿼리 수정
- ✨ 라운지 초대 수락 이벤트 구독 로직 추가

## 🔗 관련 이슈

<!-- 이 PR과 관련된 이슈 번호를 연결 (없으면 생략)) -->

- closed #272

## ℹ️ 참고 사항

<!-- 리뷰어가 알 필요가 있는 추가 정보나 문서, 참고 링크를 포함 -->

- 라운지 초대시 초대받은 유저가 수락하기 전에 라운지 멤버로 초대되는 버그 해결 후, QA가 필요합니다. @junseoparkk 