### PR TITLE
라운지 도메인 리팩토링

### DIFF
--- a/src/main/java/com/example/daobe/lounge/application/LoungeFacadeService.java
+++ b/src/main/java/com/example/daobe/lounge/application/LoungeFacadeService.java
@@ -2,9 +2,9 @@ package com.example.daobe.lounge.application;
 
 import com.example.daobe.lounge.application.dto.LoungeCreateRequestDto;
 import com.example.daobe.lounge.application.dto.LoungeCreateResponseDto;
-import com.example.daobe.lounge.application.dto.LoungeDetailInfoDto;
-import com.example.daobe.lounge.application.dto.LoungeInfoDto;
-import com.example.daobe.lounge.application.dto.LoungeInviteDto;
+import com.example.daobe.lounge.application.dto.LoungeDetailResponseDto;
+import com.example.daobe.lounge.application.dto.LoungeInfoResponseDto;
+import com.example.daobe.lounge.application.dto.LoungeInviteRequestDto;
 import com.example.daobe.lounge.application.dto.LoungeSharerInfoResponseDto;
 import com.example.daobe.lounge.application.dto.LoungeValidateRequestDto;
 import com.example.daobe.lounge.domain.Lounge;
@@ -34,12 +34,12 @@ public class LoungeFacadeService {
     }
 
     // 라운지 목록 조회
-    public List<LoungeInfoDto> getAllLounges(Long userId) {
+    public List<LoungeInfoResponseDto> getAllLounges(Long userId) {
         return loungeService.getLoungeInfosByUserId(userId);
     }
 
     // 라운지 상세 조회
-    public LoungeDetailInfoDto getLoungeDetail(Long userId, Long loungeId) {
+    public LoungeDetailResponseDto getLoungeDetail(Long userId, Long loungeId) {
         Lounge findLounge = loungeService.getLoungeById(loungeId);
         loungeSharerService.validateLoungeSharer(userId, loungeId);
         return loungeService.getLoungeDetailInfo(findLounge);
@@ -55,7 +55,7 @@ public class LoungeFacadeService {
 
     // 라운지 초대
     @Transactional
-    public void inviteUser(LoungeInviteDto request, Long inviterId) {
+    public void inviteUser(LoungeInviteRequestDto request, Long inviterId) {
         User findUser = userService.getUserById(request.userId());
         Lounge findLounge = loungeService.getLoungeById(request.loungeId());
         loungeSharerService.inviteUser(findUser, findLounge, inviterId);

--- a/src/main/java/com/example/daobe/lounge/application/LoungeFacadeService.java
+++ b/src/main/java/com/example/daobe/lounge/application/LoungeFacadeService.java
@@ -48,9 +48,9 @@ public class LoungeFacadeService {
     // 라운지 삭제
     @Transactional
     public void deleteLounge(Long userId, Long loungeId) {
-        User findUser = userService.getUserById(userId);
-        Lounge findLounge = loungeService.getLoungeById(loungeId);
-        loungeService.deleteLoungeByUserId(findUser, findLounge);
+        userService.getUserById(userId);
+        Lounge lounge = loungeService.getLoungeById(loungeId);
+        loungeService.deleteLoungeByUserId(userId, lounge);
     }
 
     // 라운지 초대

--- a/src/main/java/com/example/daobe/lounge/application/LoungeService.java
+++ b/src/main/java/com/example/daobe/lounge/application/LoungeService.java
@@ -3,8 +3,8 @@ package com.example.daobe.lounge.application;
 import static com.example.daobe.lounge.exception.LoungeExceptionType.INVALID_LOUNGE_ID_EXCEPTION;
 
 import com.example.daobe.lounge.application.dto.LoungeCreateRequestDto;
-import com.example.daobe.lounge.application.dto.LoungeDetailInfoDto;
-import com.example.daobe.lounge.application.dto.LoungeInfoDto;
+import com.example.daobe.lounge.application.dto.LoungeDetailResponseDto;
+import com.example.daobe.lounge.application.dto.LoungeInfoResponseDto;
 import com.example.daobe.lounge.domain.Lounge;
 import com.example.daobe.lounge.domain.LoungeStatus;
 import com.example.daobe.lounge.domain.LoungeType;
@@ -37,16 +37,16 @@ public class LoungeService {
         return lounge;
     }
 
-    public List<LoungeInfoDto> getLoungeInfosByUserId(Long userId) {
+    public List<LoungeInfoResponseDto> getLoungeInfosByUserId(Long userId) {
         return loungeRepository.findLoungeByUserId(userId).stream()
                 .filter(lounge -> lounge.getStatus().isActive())
-                .map(LoungeInfoDto::of)
+                .map(LoungeInfoResponseDto::of)
                 .toList();
     }
 
-    public LoungeDetailInfoDto getLoungeDetailInfo(Lounge lounge) {
+    public LoungeDetailResponseDto getLoungeDetailInfo(Lounge lounge) {
         lounge.isActiveOrThrow();
-        return LoungeDetailInfoDto.of(lounge);
+        return LoungeDetailResponseDto.of(lounge);
     }
 
     public Lounge getLoungeById(Long loungeId) {

--- a/src/main/java/com/example/daobe/lounge/application/LoungeService.java
+++ b/src/main/java/com/example/daobe/lounge/application/LoungeService.java
@@ -6,8 +6,6 @@ import com.example.daobe.lounge.application.dto.LoungeCreateRequestDto;
 import com.example.daobe.lounge.application.dto.LoungeDetailResponseDto;
 import com.example.daobe.lounge.application.dto.LoungeInfoResponseDto;
 import com.example.daobe.lounge.domain.Lounge;
-import com.example.daobe.lounge.domain.LoungeStatus;
-import com.example.daobe.lounge.domain.LoungeType;
 import com.example.daobe.lounge.domain.event.LoungeDeletedEvent;
 import com.example.daobe.lounge.domain.repository.LoungeRepository;
 import com.example.daobe.lounge.exception.LoungeException;
@@ -30,8 +28,7 @@ public class LoungeService {
         Lounge lounge = Lounge.builder()
                 .user(user)
                 .name(request.name())
-                .type(LoungeType.from(request.type()))
-                .status(LoungeStatus.ACTIVE)
+                .type(request.type())
                 .build();
         loungeRepository.save(lounge);
         return lounge;
@@ -39,7 +36,7 @@ public class LoungeService {
 
     public List<LoungeInfoResponseDto> getLoungeInfosByUserId(Long userId) {
         return loungeRepository.findLoungeByUserId(userId).stream()
-                .filter(lounge -> lounge.getStatus().isActive())
+                .filter(Lounge::isActive)
                 .map(LoungeInfoResponseDto::of)
                 .toList();
     }
@@ -54,8 +51,8 @@ public class LoungeService {
                 .orElseThrow(() -> new LoungeException(INVALID_LOUNGE_ID_EXCEPTION));
     }
 
-    public void deleteLoungeByUserId(User user, Lounge lounge) {
-        lounge.softDelete(user.getId());
+    public void deleteLoungeByUserId(Long userId, Lounge lounge) {
+        lounge.softDelete(userId);
         eventPublisher.publishEvent(new LoungeDeletedEvent(lounge.getId()));
     }
 }

--- a/src/main/java/com/example/daobe/lounge/application/LoungeSharerService.java
+++ b/src/main/java/com/example/daobe/lounge/application/LoungeSharerService.java
@@ -73,7 +73,7 @@ public class LoungeSharerService {
     public List<LoungeSharerInfoResponseDto> searchLoungeSharer(Long userId, String nickname, Lounge lounge) {
         validateLoungeSharer(userId, lounge.getId());
         List<LoungeSharer> byUserId = loungeSharerRepository
-                .findByLounge_IdAndUser_NicknameContaining(lounge.getId(), nickname);
+                .findActiveSharersByLoungeIdAndNickname(lounge.getId(), nickname);
         return LoungeSharerInfoResponseDto.of(byUserId);
     }
 

--- a/src/main/java/com/example/daobe/lounge/application/dto/LoungeDetailResponseDto.java
+++ b/src/main/java/com/example/daobe/lounge/application/dto/LoungeDetailResponseDto.java
@@ -2,15 +2,15 @@ package com.example.daobe.lounge.application.dto;
 
 import com.example.daobe.lounge.domain.Lounge;
 
-public record LoungeDetailInfoDto(
+public record LoungeDetailResponseDto(
         Long loungeId,
         String name,
         String type,
         Long userId
 ) {
 
-    public static LoungeDetailInfoDto of(Lounge lounge) {
-        return new LoungeDetailInfoDto(
+    public static LoungeDetailResponseDto of(Lounge lounge) {
+        return new LoungeDetailResponseDto(
                 lounge.getId(),
                 lounge.getName(),
                 lounge.getType().getTypeName(),

--- a/src/main/java/com/example/daobe/lounge/application/dto/LoungeInfoResponseDto.java
+++ b/src/main/java/com/example/daobe/lounge/application/dto/LoungeInfoResponseDto.java
@@ -2,14 +2,14 @@ package com.example.daobe.lounge.application.dto;
 
 import com.example.daobe.lounge.domain.Lounge;
 
-public record LoungeInfoDto(
+public record LoungeInfoResponseDto(
         Long loungeId,
         String name,
         String type
 ) {
 
-    public static LoungeInfoDto of(Lounge lounge) {
-        return new LoungeInfoDto(
+    public static LoungeInfoResponseDto of(Lounge lounge) {
+        return new LoungeInfoResponseDto(
                 lounge.getId(),
                 lounge.getName(),
                 lounge.getType().getTypeName()

--- a/src/main/java/com/example/daobe/lounge/application/dto/LoungeInviteRequestDto.java
+++ b/src/main/java/com/example/daobe/lounge/application/dto/LoungeInviteRequestDto.java
@@ -1,6 +1,6 @@
 package com.example.daobe.lounge.application.dto;
 
-public record LoungeInviteDto(
+public record LoungeInviteRequestDto(
         Long userId,
         Long loungeId
 ) {

--- a/src/main/java/com/example/daobe/lounge/domain/Lounge.java
+++ b/src/main/java/com/example/daobe/lounge/domain/Lounge.java
@@ -54,18 +54,18 @@ public class Lounge extends BaseTimeEntity {
     private String reasonDetail;
 
     @Builder
-    public Lounge(User user, String name, LoungeType type, LoungeStatus status) {
+    public Lounge(User user, String name, String type) {
         this.user = user;
         this.name = name;
-        this.type = type;
-        this.status = status;
+        this.type = LoungeType.from(type);
+        this.status = LoungeStatus.ACTIVE;
     }
 
-    public Lounge(Long id, User user, String name, LoungeType type, LoungeStatus status) {
+    public Lounge(Long id, User user, String name, String type, LoungeStatus status) {
         this.id = id;
         this.user = user;
         this.name = name;
-        this.type = type;
+        this.type = LoungeType.from(type);
         this.status = status;
     }
 
@@ -75,15 +75,13 @@ public class Lounge extends BaseTimeEntity {
         this.status = LoungeStatus.DELETED;
     }
 
+    public boolean isActive() {
+        return status.isActive();
+    }
+
     public void isActiveOrThrow() {
         if (!status.isActive()) {
             throw new LoungeException(NOT_ACTIVE_LOUNGE_EXCEPTION);
-        }
-    }
-
-    public void isOwnerOrThrow(Long userId) {
-        if (userId != user.getId()) {
-            throw new LoungeException(INVALID_LOUNGE_OWNER_EXCEPTION);
         }
     }
 
@@ -91,6 +89,12 @@ public class Lounge extends BaseTimeEntity {
         isActiveOrThrow();
         if (userId == user.getId()) {
             throw new LoungeException(NOT_ALLOW_LOUNGE_WITHDRAW_EXCEPTION);
+        }
+    }
+
+    private void isOwnerOrThrow(Long userId) {
+        if (userId != user.getId()) {
+            throw new LoungeException(INVALID_LOUNGE_OWNER_EXCEPTION);
         }
     }
 }

--- a/src/main/java/com/example/daobe/lounge/domain/Lounge.java
+++ b/src/main/java/com/example/daobe/lounge/domain/Lounge.java
@@ -8,6 +8,7 @@ import com.example.daobe.common.domain.BaseTimeEntity;
 import com.example.daobe.lounge.exception.LoungeException;
 import com.example.daobe.user.domain.User;
 import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -38,8 +39,8 @@ public class Lounge extends BaseTimeEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     private User user;
 
-    @Column(name = "name")
-    private String name;
+    @Embedded
+    private LoungeName name;
 
     @Enumerated(EnumType.STRING)
     private LoungeType type;
@@ -56,7 +57,7 @@ public class Lounge extends BaseTimeEntity {
     @Builder
     public Lounge(User user, String name, String type) {
         this.user = user;
-        this.name = name;
+        this.name = new LoungeName(name);
         this.type = LoungeType.from(type);
         this.status = LoungeStatus.ACTIVE;
     }
@@ -64,7 +65,7 @@ public class Lounge extends BaseTimeEntity {
     public Lounge(Long id, User user, String name, String type, LoungeStatus status) {
         this.id = id;
         this.user = user;
-        this.name = name;
+        this.name = new LoungeName(name);
         this.type = LoungeType.from(type);
         this.status = status;
     }
@@ -90,6 +91,10 @@ public class Lounge extends BaseTimeEntity {
         if (userId == user.getId()) {
             throw new LoungeException(NOT_ALLOW_LOUNGE_WITHDRAW_EXCEPTION);
         }
+    }
+
+    public String getName() {
+        return name.getName();
     }
 
     private void isOwnerOrThrow(Long userId) {

--- a/src/main/java/com/example/daobe/lounge/domain/LoungeName.java
+++ b/src/main/java/com/example/daobe/lounge/domain/LoungeName.java
@@ -1,0 +1,44 @@
+package com.example.daobe.lounge.domain;
+
+import static com.example.daobe.lounge.exception.LoungeExceptionType.LOUNGE_NAME_LENGTH_EXCEPTION;
+import static com.example.daobe.lounge.exception.LoungeExceptionType.LOUNGE_NAME_REGEX_EXCEPTION;
+
+import com.example.daobe.lounge.exception.LoungeException;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+
+@Embeddable
+public class LoungeName {
+
+    private static final int MIN_LENGTH = 2;
+    private static final int MAX_LENGTH = 10;
+    private static final String NAME_REGEX = "^(?!.*[^가-힣a-zA-Z0-9\\s])(?!.*\\s{2,}).*$";
+
+    @Column(name = "name")
+    private String name;
+
+    public LoungeName() {
+    }
+
+    public LoungeName(String name) {
+        validateLength(name.length());
+        validatePattern(name);
+        this.name = name.trim();
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    private void validateLength(int length) {
+        if (length < MIN_LENGTH || length > MAX_LENGTH) {
+            throw new LoungeException(LOUNGE_NAME_LENGTH_EXCEPTION);
+        }
+    }
+
+    private void validatePattern(String name) {
+        if (!name.matches(NAME_REGEX)) {
+            throw new LoungeException(LOUNGE_NAME_REGEX_EXCEPTION);
+        }
+    }
+}

--- a/src/main/java/com/example/daobe/lounge/domain/repository/LoungeSharerRepository.java
+++ b/src/main/java/com/example/daobe/lounge/domain/repository/LoungeSharerRepository.java
@@ -30,7 +30,14 @@ public interface LoungeSharerRepository extends JpaRepository<LoungeSharer, Long
             """)
     boolean existsLoungeSharerByUserIdAndLoungeId(@Param("userId") Long userId, @Param("loungeId") Long loungeId);
 
-    List<LoungeSharer> findByLounge_IdAndUser_NicknameContaining(Long loungeId, String nickname);
+    @Query("""
+            SELECT ls FROM LoungeSharer ls
+            WHERE ls.lounge.id = :loungeId
+            AND ls.user.nickname LIKE %:nickname%
+            AND ls.status = 'ACTIVE'
+            """)
+    List<LoungeSharer> findActiveSharersByLoungeIdAndNickname(@Param("loungeId") Long loungeId,
+                                                              @Param("nickname") String nickname);
 
     @Query("""
                 SELECT COUNT(ls) FROM LoungeSharer ls

--- a/src/main/java/com/example/daobe/lounge/exception/LoungeExceptionType.java
+++ b/src/main/java/com/example/daobe/lounge/exception/LoungeExceptionType.java
@@ -4,6 +4,9 @@ import com.example.daobe.common.exception.BaseExceptionType;
 import org.springframework.http.HttpStatus;
 
 public enum LoungeExceptionType implements BaseExceptionType {
+
+    LOUNGE_NAME_LENGTH_EXCEPTION("라운지 이름은 2글자 이상 10글자 이하여야 합니다.", HttpStatus.BAD_REQUEST),
+    LOUNGE_NAME_REGEX_EXCEPTION("라운지 이름 형식이 올바르지 않습니다.", HttpStatus.BAD_REQUEST),
     INVALID_LOUNGE_ID_EXCEPTION("유효하지 않은 라운지 ID입니다.", HttpStatus.NOT_FOUND),
     INVALID_LOUNGE_TYPE_EXCEPTION("유효하지 않은 라운지 타입입니다.", HttpStatus.BAD_REQUEST),
     NOT_ACTIVE_LOUNGE_EXCEPTION("활성 상태가 아닌 라운지입니다.", HttpStatus.NOT_FOUND),

--- a/src/main/java/com/example/daobe/lounge/presentation/LoungeController.java
+++ b/src/main/java/com/example/daobe/lounge/presentation/LoungeController.java
@@ -46,7 +46,10 @@ public class LoungeController {
     ) {
         LoungeCreateResponseDto response = loungeFacadeService.createLounge(request, userId);
         return ResponseEntity.status(LOUNGE_CREATED_SUCCESS.getHttpStatus())
-                .body(new ApiResponse<>(LOUNGE_CREATED_SUCCESS.name(), response));
+                .body(new ApiResponse<>(
+                        LOUNGE_CREATED_SUCCESS.name(),
+                        response)
+                );
     }
 
     @GetMapping
@@ -72,7 +75,6 @@ public class LoungeController {
                 );
     }
 
-    // TODO: 비활성화된 라운지 탈퇴 요청시 예외 발생하는지 확인하기
     @DeleteMapping("/{loungeId}")
     public ResponseEntity<ApiResponse<Void>> deleteLounge(
             @AuthenticationPrincipal Long userId,
@@ -80,7 +82,10 @@ public class LoungeController {
     ) {
         loungeFacadeService.deleteLounge(userId, loungeId);
         return ResponseEntity.status(LOUNGE_DELETED_SUCCESS.getHttpStatus())
-                .body(new ApiResponse<>(LOUNGE_DELETED_SUCCESS.name(), null));
+                .body(new ApiResponse<>(
+                        LOUNGE_DELETED_SUCCESS.name(),
+                        null)
+                );
     }
 
     @PostMapping("/invite")
@@ -90,7 +95,10 @@ public class LoungeController {
     ) {
         loungeFacadeService.inviteUser(request, userId);
         return ResponseEntity.status(LOUNGE_INVITE_SUCCESS.getHttpStatus())
-                .body(new ApiResponse<>(LOUNGE_INVITE_SUCCESS.name(), null));
+                .body(new ApiResponse<>(
+                        LOUNGE_INVITE_SUCCESS.name(),
+                        null)
+                );
     }
 
     @PatchMapping("/{loungeId}/invite/accept")
@@ -100,9 +108,11 @@ public class LoungeController {
     ) {
         loungeFacadeService.updateInvitedUserStatus(userId, loungeId);
         return ResponseEntity.status(LOUNGE_INVITE_SUCCESS.getHttpStatus())
-                .body(new ApiResponse<>(LOUNGE_INVITE_ACCEPTED_SUCCESS.name(), null));
+                .body(new ApiResponse<>(
+                        LOUNGE_INVITE_ACCEPTED_SUCCESS.name(),
+                        null)
+                );
     }
-
 
     @GetMapping("/{loungeId}/search")
     public ResponseEntity<ApiResponse<List<LoungeSharerInfoResponseDto>>> searchLoungeSharer(
@@ -137,8 +147,8 @@ public class LoungeController {
     ) {
         loungeFacadeService.isLoungeSharer(userId, request);
         return ResponseEntity.ok(new ApiResponse<>(
-                "AUTHENTICATION_SUCCESS", null
+                "AUTHENTICATION_SUCCESS",
+                null
         ));
-
     }
 }

--- a/src/main/java/com/example/daobe/lounge/presentation/LoungeController.java
+++ b/src/main/java/com/example/daobe/lounge/presentation/LoungeController.java
@@ -13,9 +13,9 @@ import com.example.daobe.common.response.ApiResponse;
 import com.example.daobe.lounge.application.LoungeFacadeService;
 import com.example.daobe.lounge.application.dto.LoungeCreateRequestDto;
 import com.example.daobe.lounge.application.dto.LoungeCreateResponseDto;
-import com.example.daobe.lounge.application.dto.LoungeDetailInfoDto;
-import com.example.daobe.lounge.application.dto.LoungeInfoDto;
-import com.example.daobe.lounge.application.dto.LoungeInviteDto;
+import com.example.daobe.lounge.application.dto.LoungeDetailResponseDto;
+import com.example.daobe.lounge.application.dto.LoungeInfoResponseDto;
+import com.example.daobe.lounge.application.dto.LoungeInviteRequestDto;
 import com.example.daobe.lounge.application.dto.LoungeSharerInfoResponseDto;
 import com.example.daobe.lounge.application.dto.LoungeValidateRequestDto;
 import java.util.List;
@@ -53,7 +53,7 @@ public class LoungeController {
     }
 
     @GetMapping
-    public ResponseEntity<ApiResponse<List<LoungeInfoDto>>> getAllLounges(
+    public ResponseEntity<ApiResponse<List<LoungeInfoResponseDto>>> getAllLounges(
             @AuthenticationPrincipal Long userId
     ) {
         return ResponseEntity.status(LOUNGE_LIST_LOADED_SUCCESS.getHttpStatus())
@@ -64,7 +64,7 @@ public class LoungeController {
     }
 
     @GetMapping("/{loungeId}")
-    public ResponseEntity<ApiResponse<LoungeDetailInfoDto>> getLoungeDetail(
+    public ResponseEntity<ApiResponse<LoungeDetailResponseDto>> getLoungeDetail(
             @AuthenticationPrincipal Long userId,
             @PathVariable(name = "loungeId") Long loungeId
     ) {
@@ -91,7 +91,7 @@ public class LoungeController {
     @PostMapping("/invite")
     public ResponseEntity<ApiResponse<Void>> inviteUser(
             @AuthenticationPrincipal Long userId,
-            @RequestBody LoungeInviteDto request
+            @RequestBody LoungeInviteRequestDto request
     ) {
         loungeFacadeService.inviteUser(request, userId);
         return ResponseEntity.status(LOUNGE_INVITE_SUCCESS.getHttpStatus())

--- a/src/test/java/com/example/daobe/common/fixtures/LoungeFixtures.java
+++ b/src/test/java/com/example/daobe/common/fixtures/LoungeFixtures.java
@@ -2,13 +2,12 @@ package com.example.daobe.common.fixtures;
 
 import com.example.daobe.lounge.domain.Lounge;
 import com.example.daobe.lounge.domain.LoungeStatus;
-import com.example.daobe.lounge.domain.LoungeType;
 import com.example.daobe.user.domain.User;
 
 public class LoungeFixtures {
 
     private static final String FAKE_LOUNGE_NAME = "Test Lounge";
-    private static final LoungeType FAKE_LOUNGE_TYPE = LoungeType.L0001;
+    private static final String FAKE_LOUNGE_TYPE = "L0001";
     private static final LoungeStatus ACTIVE_STATUS = LoungeStatus.ACTIVE;
     private static final LoungeStatus DELETED_STATUS = LoungeStatus.DELETED;
 

--- a/src/test/java/com/example/daobe/common/fixtures/LoungeFixtures.java
+++ b/src/test/java/com/example/daobe/common/fixtures/LoungeFixtures.java
@@ -6,7 +6,7 @@ import com.example.daobe.user.domain.User;
 
 public class LoungeFixtures {
 
-    private static final String FAKE_LOUNGE_NAME = "Test Lounge";
+    private static final String FAKE_LOUNGE_NAME = "TestLounge";
     private static final String FAKE_LOUNGE_TYPE = "L0001";
     private static final LoungeStatus ACTIVE_STATUS = LoungeStatus.ACTIVE;
     private static final LoungeStatus DELETED_STATUS = LoungeStatus.DELETED;

--- a/src/test/java/com/example/daobe/lounge/domain/LoungeNameTest.java
+++ b/src/test/java/com/example/daobe/lounge/domain/LoungeNameTest.java
@@ -1,0 +1,57 @@
+package com.example.daobe.lounge.domain;
+
+import static com.example.daobe.lounge.exception.LoungeExceptionType.LOUNGE_NAME_LENGTH_EXCEPTION;
+import static com.example.daobe.lounge.exception.LoungeExceptionType.LOUNGE_NAME_REGEX_EXCEPTION;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatNoException;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+
+import com.example.daobe.lounge.exception.LoungeException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class LoungeNameTest {
+
+    @ParameterizedTest
+    @ValueSource(strings = {"안녕하세요", "Lounge1", "한글 영어 1"})
+    @DisplayName("올바른 라운지 이름인 경우 예외가 발생하지 않아야 한다.")
+    void testValidLoungeName(String validName) {
+        assertThatNoException().isThrownBy(() -> new LoungeName(validName));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"안"})
+    @DisplayName("라운지 이름이 2자 미만인 경우 예외가 발생해야 한다.")
+    void testTooShortLoungeName(String shortName) {
+        assertThatThrownBy(() -> new LoungeName(shortName))
+                .isInstanceOf(LoungeException.class)
+                .hasMessage(LOUNGE_NAME_LENGTH_EXCEPTION.message());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"안녕하세요 안녕하세요"})
+    @DisplayName("라운지 이름이 10자를 초과하는 경우 예외가 발생해야 한다.")
+    void testTooLongLoungeName(String longName) {
+        assertThatThrownBy(() -> new LoungeName(longName))
+                .isInstanceOf(LoungeException.class)
+                .hasMessage(LOUNGE_NAME_LENGTH_EXCEPTION.message());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"new@Lounge", "Lounge!", "라운지#1"})
+    @DisplayName("라운지 이름에 특수문자가 포함된 경우 예외가 발생해야 한다.")
+    void testLoungeNameWithSpecialCharacters(String invalidName) {
+        assertThatThrownBy(() -> new LoungeName(invalidName))
+                .isInstanceOf(LoungeException.class)
+                .hasMessage(LOUNGE_NAME_REGEX_EXCEPTION.message());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"Lou  nge", "라운지  이름"})
+    @DisplayName("라운지 이름에 연속된 공백이 포함된 경우 예외가 발생해야 한다.")
+    void testLoungeNameWithConsecutiveSpaces(String nameWithSpaces) {
+        assertThatThrownBy(() -> new LoungeName(nameWithSpaces))
+                .isInstanceOf(LoungeException.class)
+                .hasMessage(LOUNGE_NAME_REGEX_EXCEPTION.message());
+    }
+}


### PR DESCRIPTION
## 📝 개요

```markdown
라운지 도메인 리팩토링
```

## ✨ 변경 사항

- ✨ 라운지 초대시 활성 상태인 라운지 공유자만 조회하도록 쿼리문 조건 추가
- ✨ 라운지 이름 임베디드 타입으로 분리
- ✨ 라운지 이름 검증 로직 추가
- ✨ 라운지 이름 검증 테스트 추가
- ✨ 코드 스타일 통일

## 🔗 관련 이슈

- closed #256
